### PR TITLE
Create fixture for observing item drops

### DIFF
--- a/src/main/java/org/terasology/moduletestingenvironment/fixtures/ItemDropSpy.java
+++ b/src/main/java/org/terasology/moduletestingenvironment/fixtures/ItemDropSpy.java
@@ -91,7 +91,7 @@ public class ItemDropSpy extends BaseComponentSystem implements AutoCloseable {
      * @return the list of all items dropped during execution of {@code block}
      */
     public static List<EntityRef> collectDrops(Context context, Runnable block) {
-        List<EntityRef> drops;
+        final List<EntityRef> drops;
         try (ItemDropSpy spy = new ItemDropSpy(context)) {
             drops = spy.getDrops();
             block.run();

--- a/src/main/java/org/terasology/moduletestingenvironment/fixtures/ItemDropSpy.java
+++ b/src/main/java/org/terasology/moduletestingenvironment/fixtures/ItemDropSpy.java
@@ -36,79 +36,79 @@ import java.util.List;
  * done in a try-with-resources block ({@code ItemDropSpy} is {@link AutoCloseable}):
  * {@code
  * try (ItemDropSpy spy = new ItemDropSpy(getHostContext())) {
- *   dropExampleItems();
- *   assertTrue(spy.getDrops().exampleItemsAreCorrect());
+ *     dropExampleItems();
+ *     assertTrue(spy.getDrops().exampleItemsAreCorrect());
  * }
  * }
  * <p>
  * Alternatively, a test may call the static method {@link #collectDrops(Context, Runnable)}, which
- * may be easier to understand, especially if the code being run is a single method.  In this style,
- * the previous example would look like this:
+ * may be easier to understand, especially if the code being run is a single method.  In this
+ * style, the previous example would look like this:
  * {@code
- *   List<EntityRef> drops = ItemDropSpy.collectDrops(getHostContext(), ::dropExampleItems);
- *   assertTrue(drops.exampleItemsAreCorrect());
+ * List<EntityRef> drops = ItemDropSpy.collectDrops(getHostContext(), ::dropExampleItems);
+ * assertTrue(drops.exampleItemsAreCorrect());
  * }
  */
 public class ItemDropSpy extends BaseComponentSystem implements AutoCloseable {
 
-  private EventSystem eventSystem;
+    private EventSystem eventSystem;
 
-  private List<EntityRef> drops = new ArrayList<>();
+    private List<EntityRef> drops = new ArrayList<>();
 
-  /**
-   * Constructs a new {@code ItemDropSpy} and registers it to listen for item drops.
-   *
-   * @param context the context object for the test; this should probably be obtained through
-   *                {@link ModuleTestingEnvironment#getHostContext()} and is needed so we can
-   *                obtain an {@link EventSystem} instance to register our event handler.
-   */
-  public ItemDropSpy(Context context) {
-    eventSystem = context.get(EventSystem.class);
-    eventSystem.registerEventHandler(this);
-  }
-
-  /** Unregisters this {@code ItemDropSpy} so it stops listening for item drops. */
-  public void close() {
-    eventSystem.unregisterEventHandler(this);
-  }
-
-  /**
-   * Returns a read-only view of the list of items dropped.
-   * <p>
-   * If the {@code ItemDropSpy} has not been {@linkplain #close() closed}, then this list will
-   * continue to be updated if further item drops occur.
-   */
-  public List<EntityRef> getDrops() {
-    return Collections.unmodifiableList(drops);
-  }
-
-  /**
-   * Runs {@code block} and returns the list of all drops that occurred in the process.
-   *
-   * @param context the context object for the test, probably obtained using
-   *                {@link ModuleTestingEnvironment#getDependencies()}
-   * @param block the code to run
-   * @return the list of all items dropped during execution of {@code block}
-   */
-  public static List<EntityRef> collectDrops(Context context, Runnable block) {
-    List<EntityRef> drops;
-    try (ItemDropSpy spy = new ItemDropSpy(context)) {
-      drops = spy.getDrops();
-      block.run();
+    /**
+     * Constructs a new {@code ItemDropSpy} and registers it to listen for item drops.
+     *
+     * @param context the context object for the test; this should probably be obtained through
+     *                {@link ModuleTestingEnvironment#getHostContext()} and is needed so we can
+     *                obtain an {@link EventSystem} instance to register our event handler.
+     */
+    public ItemDropSpy(Context context) {
+        eventSystem = context.get(EventSystem.class);
+        eventSystem.registerEventHandler(this);
     }
-    return drops;
-  }
 
-  /**
-   * Records the item drop.
-   * <p>
-   * Note that this doesn't put the item in an inventory or otherwise interfere with the drop
-   * itself, but it does store a reference to the item.  Consequently, the item still exists in the
-   * world, and if other actors modify or destroy it, those changes would be reflected in the list
-   * of drops.
-   */
-  @ReceiveEvent
-  public void onItemDrop(DropItemEvent event, EntityRef item) {
-    drops.add(item);
-  }
+    /** Unregisters this {@code ItemDropSpy} so it stops listening for item drops. */
+    public void close() {
+        eventSystem.unregisterEventHandler(this);
+    }
+
+    /**
+     * Returns a read-only view of the list of items dropped.
+     * <p>
+     * If the {@code ItemDropSpy} has not been {@linkplain #close() closed}, then this list will
+     * continue to be updated if further item drops occur.
+     */
+    public List<EntityRef> getDrops() {
+        return Collections.unmodifiableList(drops);
+    }
+
+    /**
+     * Runs {@code block} and returns the list of all drops that occurred in the process.
+     *
+     * @param context the context object for the test, probably obtained using
+     *                {@link ModuleTestingEnvironment#getDependencies()}
+     * @param block the code to run
+     * @return the list of all items dropped during execution of {@code block}
+     */
+    public static List<EntityRef> collectDrops(Context context, Runnable block) {
+        List<EntityRef> drops;
+        try (ItemDropSpy spy = new ItemDropSpy(context)) {
+            drops = spy.getDrops();
+            block.run();
+        }
+        return drops;
+    }
+
+    /**
+     * Records the item drop.
+     * <p>
+     * Note that this doesn't put the item in an inventory or otherwise interfere with the drop
+     * itself, but it does store a reference to the item.  Consequently, the item still exists in
+     * the world, and if other actors modify or destroy it, those changes would be reflected in the
+     * list of drops.
+     */
+    @ReceiveEvent
+    public void onItemDrop(DropItemEvent event, EntityRef item) {
+        drops.add(item);
+    }
 }

--- a/src/main/java/org/terasology/moduletestingenvironment/fixtures/ItemDropSpy.java
+++ b/src/main/java/org/terasology/moduletestingenvironment/fixtures/ItemDropSpy.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2017 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.moduletestingenvironment.fixtures;
+
+import org.terasology.context.Context;
+import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.entitySystem.event.ReceiveEvent;
+import org.terasology.entitySystem.event.internal.EventSystem;
+import org.terasology.entitySystem.systems.BaseComponentSystem;
+import org.terasology.logic.inventory.events.DropItemEvent;
+import org.terasology.moduletestingenvironment.ModuleTestingEnvironment;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Test fixture for recording item drops.
+ * <p>
+ * Two usage patterns are supported.  A test may instantiate an {@code ItemDropSpy}, execute some
+ * code, and then examine the list of drops provided by {@link #getDrops()}.  In order to handle
+ * registration and un-registration of the event handler listening for item drops, this should be
+ * done in a try-with-resources block ({@code ItemDropSpy} is {@link AutoCloseable}):
+ * {@code
+ * try (ItemDropSpy spy = new ItemDropSpy(getHostContext())) {
+ *   dropExampleItems();
+ *   assertTrue(spy.getDrops().exampleItemsAreCorrect());
+ * }
+ * }
+ * <p>
+ * Alternatively, a test may call the static method {@link #collectDrops(Context, Runnable)}, which
+ * may be easier to understand, especially if the code being run is a single method.  In this style,
+ * the previous example would look like this:
+ * {@code
+ *   List<EntityRef> drops = ItemDropSpy.collectDrops(getHostContext(), ::dropExampleItems);
+ *   assertTrue(drops.exampleItemsAreCorrect());
+ * }
+ */
+public class ItemDropSpy extends BaseComponentSystem implements AutoCloseable {
+
+  private EventSystem eventSystem;
+
+  private List<EntityRef> drops = new ArrayList<>();
+
+  /**
+   * Constructs a new {@code ItemDropSpy} and registers it to listen for item drops.
+   *
+   * @param context the context object for the test; this should probably be obtained through
+   *                {@link ModuleTestingEnvironment#getHostContext()} and is needed so we can
+   *                obtain an {@link EventSystem} instance to register our event handler.
+   */
+  public ItemDropSpy(Context context) {
+    eventSystem = context.get(EventSystem.class);
+    eventSystem.registerEventHandler(this);
+  }
+
+  /** Unregisters this {@code ItemDropSpy} so it stops listening for item drops. */
+  public void close() {
+    eventSystem.unregisterEventHandler(this);
+  }
+
+  /**
+   * Returns a read-only view of the list of items dropped.
+   * <p>
+   * If the {@code ItemDropSpy} has not been {@linkplain #close() closed}, then this list will
+   * continue to be updated if further item drops occur.
+   */
+  public List<EntityRef> getDrops() {
+    return Collections.unmodifiableList(drops);
+  }
+
+  /**
+   * Runs {@code block} and returns the list of all drops that occurred in the process.
+   *
+   * @param context the context object for the test, probably obtained using
+   *                {@link ModuleTestingEnvironment#getDependencies()}
+   * @param block the code to run
+   * @return the list of all items dropped during execution of {@code block}
+   */
+  public static List<EntityRef> collectDrops(Context context, Runnable block) {
+    List<EntityRef> drops;
+    try (ItemDropSpy spy = new ItemDropSpy(context)) {
+      drops = spy.getDrops();
+      block.run();
+    }
+    return drops;
+  }
+
+  /**
+   * Records the item drop.
+   * <p>
+   * Note that this doesn't put the item in an inventory or otherwise interfere with the drop
+   * itself, but it does store a reference to the item.  Consequently, the item still exists in the
+   * world, and if other actors modify or destroy it, those changes would be reflected in the list
+   * of drops.
+   */
+  @ReceiveEvent
+  public void onItemDrop(DropItemEvent event, EntityRef item) {
+    drops.add(item);
+  }
+}

--- a/src/test/java/org/terasology/moduletestingenvironment/fixtures/ItemDropSpyTest.java
+++ b/src/test/java/org/terasology/moduletestingenvironment/fixtures/ItemDropSpyTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2017 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.moduletestingenvironment.fixtures;
+
+import com.google.common.collect.Sets;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.terasology.entitySystem.entity.EntityManager;
+import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.logic.inventory.events.DropItemEvent;
+import org.terasology.math.geom.Vector3f;
+import org.terasology.moduletestingenvironment.ModuleTestingEnvironment;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.Assert.*;
+
+public class ItemDropSpyTest extends ModuleTestingEnvironment {
+
+  @Rule
+  public final ExpectedException exception = ExpectedException.none();
+
+  @Override
+  public Set<String> getDependencies() {
+    return Sets.newHashSet("engine", "ModuleTestingEnvironment");
+  }
+
+  @Test
+  public void cumulativeDropsTest() {
+    final List<EntityRef> referenceDrops = new ArrayList<>();
+    try (ItemDropSpy spy = new ItemDropSpy(getHostContext())) {
+      List<EntityRef> drops = spy.getDrops();
+      assertTrue(drops.isEmpty());
+      for (int i = 0; i < 5; i++) {
+        referenceDrops.add(dropItem());
+        assertEquals(i + 1, drops.size());
+        assertEquals(referenceDrops.get(i), drops.get(i));
+      }
+    }
+  }
+
+  @Test
+  public void properClosureTest() {
+    List<EntityRef> drops;
+    try (ItemDropSpy spy = new ItemDropSpy(getHostContext())) {
+      drops = spy.getDrops();
+    }
+    dropItem();
+    assertTrue(drops.isEmpty());
+  }
+
+  @Test
+  public void staticUsageTest() {
+    /* We need to wrap this forward declaration in an atom so it can be final and the lambda will
+     * close over it properly. */
+    final AtomicReference<List<EntityRef>> referenceDropsAtom = new AtomicReference<>();
+    final List<EntityRef> staticDrops = ItemDropSpy.collectDrops(getHostContext(), () -> {
+      try (ItemDropSpy referenceSpy = new ItemDropSpy(getHostContext())) {
+        referenceDropsAtom.set(referenceSpy.getDrops());
+        dropItem();
+      }
+    });
+    assertEquals(referenceDropsAtom.get().size(), staticDrops.size());
+    assertEquals(referenceDropsAtom.get().get(0), staticDrops.get(0));
+  }
+
+  @Test
+  public void readOnlyTest() {
+    List<EntityRef> drops = ItemDropSpy.collectDrops(getHostContext(), this::dropItem);
+    exception.expect(UnsupportedOperationException.class);
+    drops.add(EntityRef.NULL);
+  }
+
+  /**
+   * Drops a generic item into the world.
+   *
+   * @return the item
+   */
+  private EntityRef dropItem() {
+    final EntityManager entityManager = getHostContext().get(EntityManager.class);
+    EntityRef item = entityManager.create("engine:iconItem");
+    item.send(new DropItemEvent(Vector3f.zero()));
+    return item;
+  }
+}

--- a/src/test/java/org/terasology/moduletestingenvironment/fixtures/ItemDropSpyTest.java
+++ b/src/test/java/org/terasology/moduletestingenvironment/fixtures/ItemDropSpyTest.java
@@ -34,69 +34,69 @@ import static org.junit.Assert.*;
 
 public class ItemDropSpyTest extends ModuleTestingEnvironment {
 
-  @Rule
-  public final ExpectedException exception = ExpectedException.none();
+    @Rule
+    public final ExpectedException exception = ExpectedException.none();
 
-  @Override
-  public Set<String> getDependencies() {
-    return Sets.newHashSet("engine", "ModuleTestingEnvironment");
-  }
-
-  @Test
-  public void cumulativeDropsTest() {
-    final List<EntityRef> referenceDrops = new ArrayList<>();
-    try (ItemDropSpy spy = new ItemDropSpy(getHostContext())) {
-      List<EntityRef> drops = spy.getDrops();
-      assertTrue(drops.isEmpty());
-      for (int i = 0; i < 5; i++) {
-        referenceDrops.add(dropItem());
-        assertEquals(i + 1, drops.size());
-        assertEquals(referenceDrops.get(i), drops.get(i));
-      }
+    @Override
+    public Set<String> getDependencies() {
+        return Sets.newHashSet("engine", "ModuleTestingEnvironment");
     }
-  }
 
-  @Test
-  public void properClosureTest() {
-    List<EntityRef> drops;
-    try (ItemDropSpy spy = new ItemDropSpy(getHostContext())) {
-      drops = spy.getDrops();
+    @Test
+    public void cumulativeDropsTest() {
+        final List<EntityRef> referenceDrops = new ArrayList<>();
+        try (ItemDropSpy spy = new ItemDropSpy(getHostContext())) {
+            List<EntityRef> drops = spy.getDrops();
+            assertTrue(drops.isEmpty());
+            for (int i = 0; i < 5; i++) {
+                referenceDrops.add(dropItem());
+                assertEquals(i + 1, drops.size());
+                assertEquals(referenceDrops.get(i), drops.get(i));
+            }
+        }
     }
-    dropItem();
-    assertTrue(drops.isEmpty());
-  }
 
-  @Test
-  public void staticUsageTest() {
-    /* We need to wrap this forward declaration in an atom so it can be final and the lambda will
-     * close over it properly. */
-    final AtomicReference<List<EntityRef>> referenceDropsAtom = new AtomicReference<>();
-    final List<EntityRef> staticDrops = ItemDropSpy.collectDrops(getHostContext(), () -> {
-      try (ItemDropSpy referenceSpy = new ItemDropSpy(getHostContext())) {
-        referenceDropsAtom.set(referenceSpy.getDrops());
+    @Test
+    public void properClosureTest() {
+        List<EntityRef> drops;
+        try (ItemDropSpy spy = new ItemDropSpy(getHostContext())) {
+            drops = spy.getDrops();
+        }
         dropItem();
-      }
-    });
-    assertEquals(referenceDropsAtom.get().size(), staticDrops.size());
-    assertEquals(referenceDropsAtom.get().get(0), staticDrops.get(0));
-  }
+        assertTrue(drops.isEmpty());
+    }
 
-  @Test
-  public void readOnlyTest() {
-    List<EntityRef> drops = ItemDropSpy.collectDrops(getHostContext(), this::dropItem);
-    exception.expect(UnsupportedOperationException.class);
-    drops.add(EntityRef.NULL);
-  }
+    @Test
+    public void staticUsageTest() {
+        /* We need to wrap this forward declaration in an atom so it can be final and the lambda
+        /* will close over it properly. */
+        final AtomicReference<List<EntityRef>> referenceDropsAtom = new AtomicReference<>();
+        final List<EntityRef> staticDrops = ItemDropSpy.collectDrops(getHostContext(), () -> {
+            try (ItemDropSpy referenceSpy = new ItemDropSpy(getHostContext())) {
+                referenceDropsAtom.set(referenceSpy.getDrops());
+                dropItem();
+            }
+        });
+        assertEquals(referenceDropsAtom.get().size(), staticDrops.size());
+        assertEquals(referenceDropsAtom.get().get(0), staticDrops.get(0));
+    }
 
-  /**
-   * Drops a generic item into the world.
-   *
-   * @return the item
-   */
-  private EntityRef dropItem() {
-    final EntityManager entityManager = getHostContext().get(EntityManager.class);
-    EntityRef item = entityManager.create("engine:iconItem");
-    item.send(new DropItemEvent(Vector3f.zero()));
-    return item;
-  }
+    @Test
+    public void readOnlyTest() {
+        List<EntityRef> drops = ItemDropSpy.collectDrops(getHostContext(), this::dropItem);
+        exception.expect(UnsupportedOperationException.class);
+        drops.add(EntityRef.NULL);
+    }
+
+    /**
+     * Drops a generic item into the world.
+     *
+     * @return the item
+     */
+    private EntityRef dropItem() {
+        final EntityManager entityManager = getHostContext().get(EntityManager.class);
+        EntityRef item = entityManager.create("engine:iconItem");
+        item.send(new DropItemEvent(Vector3f.zero()));
+        return item;
+    }
 }

--- a/src/test/java/org/terasology/moduletestingenvironment/fixtures/ItemDropSpyTest.java
+++ b/src/test/java/org/terasology/moduletestingenvironment/fixtures/ItemDropSpyTest.java
@@ -68,8 +68,7 @@ public class ItemDropSpyTest extends ModuleTestingEnvironment {
 
     @Test
     public void staticUsageTest() {
-        /* We need to wrap this forward declaration in an atom so it can be final and the lambda
-        /* will close over it properly. */
+        // This forward declaration is wrapped in an atom so it can be final and the lambda will close over it.
         final AtomicReference<List<EntityRef>> referenceDropsAtom = new AtomicReference<>();
         final List<EntityRef> staticDrops = ItemDropSpy.collectDrops(getHostContext(), () -> {
             try (ItemDropSpy referenceSpy = new ItemDropSpy(getHostContext())) {

--- a/src/test/java/org/terasology/moduletestingenvironment/fixtures/ItemDropSpyTest.java
+++ b/src/test/java/org/terasology/moduletestingenvironment/fixtures/ItemDropSpyTest.java
@@ -58,7 +58,7 @@ public class ItemDropSpyTest extends ModuleTestingEnvironment {
 
     @Test
     public void properClosureTest() {
-        List<EntityRef> drops;
+        final List<EntityRef> drops;
         try (ItemDropSpy spy = new ItemDropSpy(getHostContext())) {
             drops = spy.getDrops();
         }
@@ -82,7 +82,7 @@ public class ItemDropSpyTest extends ModuleTestingEnvironment {
 
     @Test
     public void readOnlyTest() {
-        List<EntityRef> drops = ItemDropSpy.collectDrops(getHostContext(), this::dropItem);
+        final List<EntityRef> drops = ItemDropSpy.collectDrops(getHostContext(), this::dropItem);
         exception.expect(UnsupportedOperationException.class);
         drops.add(EntityRef.NULL);
     }
@@ -94,7 +94,7 @@ public class ItemDropSpyTest extends ModuleTestingEnvironment {
      */
     private EntityRef dropItem() {
         final EntityManager entityManager = getHostContext().get(EntityManager.class);
-        EntityRef item = entityManager.create("engine:iconItem");
+        final EntityRef item = entityManager.create("engine:iconItem");
         item.send(new DropItemEvent(Vector3f.zero()));
         return item;
     }


### PR DESCRIPTION
### Contains

A new test fixture for observing item drops.  I created this for the tests I am currently writing for the `SimpleFarming` module but felt that it belongs here instead, since nothing about it is specific to that module.