### PR TITLE
Fixed problem that was causing MTE tests to crash

### DIFF
--- a/src/main/java/org/terasology/moduletestingenvironment/ModuleTestingEnvironment.java
+++ b/src/main/java/org/terasology/moduletestingenvironment/ModuleTestingEnvironment.java
@@ -51,15 +51,11 @@ import org.terasology.math.geom.Vector3i;
 import org.terasology.network.JoinStatus;
 import org.terasology.network.NetworkSystem;
 import org.terasology.registry.CoreRegistry;
-import org.terasology.utilities.LWJGLHelper;
+import org.terasology.rendering.opengl.ScreenGrabber;
 import org.terasology.world.RelevanceRegionComponent;
 import org.terasology.world.WorldProvider;
 
-import java.net.URL;
-import java.net.URLClassLoader;
 import java.nio.file.FileSystem;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.List;
 import java.util.Set;
 import java.util.function.Supplier;
@@ -115,6 +111,8 @@ public class ModuleTestingEnvironment {
     @Before
     public void setup() throws Exception {
         host = createHost();
+        ScreenGrabber grabber = new ScreenGrabber();
+        hostContext.put(ScreenGrabber.class, grabber);
         CoreRegistry.put(GameEngine.class, host);
     }
 
@@ -193,6 +191,8 @@ public class ModuleTestingEnvironment {
         TerasologyEngine terasologyEngine = createHeadlessEngine();
         terasologyEngine.changeState(new StateMainMenu());
         connectToHost(terasologyEngine);
+        Context context = terasologyEngine.getState().getContext();
+        context.put(ScreenGrabber.class, hostContext.get(ScreenGrabber.class));
         return terasologyEngine.getState().getContext();
     }
 

--- a/src/main/java/org/terasology/rendering/opengl/ScreenGrabber.java
+++ b/src/main/java/org/terasology/rendering/opengl/ScreenGrabber.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2017 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.rendering.opengl;
+
+import java.awt.image.BufferedImage;
+import java.nio.ByteBuffer;
+import java.nio.file.Path;
+
+
+public class ScreenGrabber {
+
+    public ScreenGrabber() {
+
+    }
+
+    public float getExposure() {
+        return 0.0f;
+    }
+
+    // TODO: Remove this method, temporarily here for DownSampleSceneAndUpdateExposure
+    public void setExposure(float exposure) {
+
+    }
+
+    public void takeScreenshot() {
+
+    }
+
+
+    public void saveScreenshot() {
+
+    }
+
+    private void saveScreenshotTask(ByteBuffer buffer, int width, int height) {
+
+    }
+
+    private void saveGamePreviewTask(ByteBuffer buffer, int width, int height) {
+
+    }
+
+    private void writeImageToFile(BufferedImage image, Path path, String format) {
+
+    }
+
+    private BufferedImage convertByteBufferToBufferedImage(ByteBuffer buffer, int width, int height) {
+        return null;
+    }
+
+    private Path getScreenshotPath(final int width, final int height, final String format) {
+        return null;
+    }
+
+
+    public boolean isTakingScreenshot() {
+        return false;
+    }
+
+
+    public void takeGamePreview(Path path) {
+
+    }
+}

--- a/src/test/java/org/terasology/moduletestingenvironment/ExampleTest.java
+++ b/src/test/java/org/terasology/moduletestingenvironment/ExampleTest.java
@@ -20,9 +20,6 @@ import com.google.common.collect.Sets;
 import org.junit.Assert;
 import org.junit.Test;
 import org.terasology.context.Context;
-import org.terasology.engine.GameEngine;
-import org.terasology.engine.TerasologyEngine;
-import org.terasology.engine.modes.StateIngame;
 import org.terasology.entitySystem.entity.EntityManager;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.logic.players.LocalPlayer;
@@ -33,8 +30,6 @@ import org.terasology.network.ClientComponent;
 import org.terasology.world.WorldProvider;
 import org.terasology.world.block.BlockManager;
 
-import java.net.URI;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 

--- a/src/test/java/org/terasology/moduletestingenvironment/WorldProviderTest.java
+++ b/src/test/java/org/terasology/moduletestingenvironment/WorldProviderTest.java
@@ -18,11 +18,7 @@ package org.terasology.moduletestingenvironment;
 import com.google.common.collect.Sets;
 import org.junit.Assert;
 import org.junit.Test;
-import org.terasology.entitySystem.entity.EntityManager;
-import org.terasology.logic.location.LocationComponent;
-import org.terasology.math.geom.Vector3f;
 import org.terasology.math.geom.Vector3i;
-import org.terasology.world.RelevanceRegionComponent;
 import org.terasology.world.WorldProvider;
 import org.terasology.world.block.BlockManager;
 


### PR DESCRIPTION
MTE tests were crashing when using StateIngame because of the new feature that takes screenshots of the game to use it in the selection menus. Since MTE works on a headless server, this feature is useless to it, therefore to fix the problem I rewrote ScreenGrabber in MTE to have all methods empty or returning the base value of its return type. I also did a small refactoring and removed some unused imports.