### PR TITLE
feat: Open up MTE for use via composition (instead of inheritance)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,13 @@ A test helper to instantiate a full headless TerasologyEngine instance
 
 ## Usage
 
-Just write a test class that `extends ModuleTestingEnvironment`.
+There are two options how to use the **Module Testing Environment** for writing module tests.
+
+The first variant is to write a test class that `extends ModuleTestingEnvironment`. 
+With this setup, a new engine will be spun up for each method annotated with `@Test` automatically.
+
+For more control and possible reuse of engine instances for multiple tests the module testing environment can be used explicitly. 
+This requires manual setup and tear down, but allows to run multiple tests against the same engine instance.
 
 For complete docs please see the
 [documentation on Github Pages](https://terasology.github.io/ModuleTestingEnvironment/org/terasology/moduletestingenvironment/ModuleTestingEnvironment.html)

--- a/src/main/java/org/terasology/moduletestingenvironment/ModuleTestingEnvironment.java
+++ b/src/main/java/org/terasology/moduletestingenvironment/ModuleTestingEnvironment.java
@@ -202,7 +202,7 @@ public class ModuleTestingEnvironment {
         return Lists.newArrayList(engines);
     }
 
-    protected Context getHostContext() {
+    public Context getHostContext() {
         return hostContext;
     }
 

--- a/src/test/java/org/terasology/moduletestingenvironment/ReuseEngineTest.java
+++ b/src/test/java/org/terasology/moduletestingenvironment/ReuseEngineTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2020 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.terasology.moduletestingenvironment;
+
+import com.google.common.collect.Sets;
+import org.junit.Assert;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.terasology.entitySystem.entity.EntityManager;
+import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.moduletestingenvironment.fixtures.DummyComponent;
+import org.terasology.moduletestingenvironment.fixtures.DummyEvent;
+
+import java.util.Set;
+
+public class ReuseEngineTest {
+    private static ModuleTestingEnvironment mte;
+    private EntityRef entity;
+
+    @BeforeAll
+    public static void setup() throws Exception {
+        mte = new ModuleTestingEnvironment() {
+            @Override
+            public Set<String> getDependencies() {
+                return Sets.newHashSet("ModuleTestingEnvironment");
+            }
+        };
+        mte.setup();
+    }
+
+    @AfterAll
+    public static void tearDown() {
+        mte.tearDown();
+    }
+
+    /**
+     * Create a new entity for each test and store it in {@code entity}.
+     */
+    @BeforeEach
+    public void prepareEntityForTest() {
+        EntityManager entityManager = mte.getHostContext().get(EntityManager.class);
+        entity = entityManager.create(new DummyComponent());
+    }
+
+    @Test
+    public void someTest() {
+        entity.send(new DummyEvent());
+        Assert.assertTrue(entity.getComponent(DummyComponent.class).dummy);
+    }
+
+    @Test
+    public void someOtherTest() {
+        Assert.assertTrue(entity.hasComponent(DummyComponent.class));
+    }
+}


### PR DESCRIPTION
This opens up the `protected` methods of `ModuleTestingEnvironment` to be `public` instead. This allows to use the MTE via composition instead of inheritance, allowing to set it up and tear it down only once per test class.

```java
	private static ModuleTestingEnvironment context;

    @BeforeAll
    public static void setup() throws Exception {
        context = new ModuleTestingEnvironment() {
            @Override
            public Set<String> getDependencies() {
                return Sets.newHashSet("Inventory");
            }
        };
        context.setup();
    }

    @AfterAll
    public static void tearDown() throws Exception {
        context.tearDown();
    }

	@Test
    public void someTest() {
		Context hostContext = context.getHostContext();
		EntityManager entityManager = hostContext.get(EntityManager.class);
		// ... 
	}
```

Simply chaning this behavior direclty in the MTE did not work as the configuration via overriding hook methods does not work with `static` methods as required for `@BeforeClass`/`@BeforeAll`.

@jellysnake please let me know if you see any problems with opening up the API in this way.

---

This was driven by the following observation:

- even empty tests will spin up a full game and load a world. this takes about ~2min on my machine. I expect this to be even longer on machines with weaker hardware
- this is done for each test annotated with `@Test`, taking again ~2min per test

Looking at Inventory tests, this leads to the following:
- :arrow_right: for testing `InventoryManger::giveItem` (for blocks and items, different stack sizes, stackability, ...) this would sum up to ~40 minutes
- :arrow_right: with dual tests for `InventoryManager::removeItem` this would add another ~40 minutes (probably even more)
- :arrow_right: with even more tests for `StartingInventorySystem` we are targeting a total run time of 2-3 hours just for this module :rolling_eyes: :see_no_evil: