### PR TITLE
feat(Junit5): Migrate to junit 5 and implement MTEExtension

### DIFF
--- a/src/main/java/org/terasology/moduletestingenvironment/MTEExtension.java
+++ b/src/main/java/org/terasology/moduletestingenvironment/MTEExtension.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2020 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.terasology.moduletestingenvironment;
+
+import com.google.common.collect.Sets;
+import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.ParameterResolutionException;
+import org.junit.jupiter.api.extension.ParameterResolver;
+import org.junit.jupiter.api.extension.TestInstancePostProcessor;
+import org.opentest4j.MultipleFailuresError;
+import org.terasology.moduletestingenvironment.extension.Dependencies;
+import org.terasology.moduletestingenvironment.extension.UseWorldGenerator;
+import org.terasology.registry.In;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Junit 5 Extension for using {@link ModuleTestingEnvironment} in your test.
+ * <p>
+ * Supports Terasology's DI as in usual Systems. You can inject Managers via {@link In} annotation, constructor's or
+ * test's parameters. Also you can inject {@link ModuleTestingEnvironment} itself.
+ * <p>
+ * Every testclass used this create one {@link ModuleTestingEnvironment} and use it during execution all tests in
+ * class.
+ * <p>
+ * Use this within {@link org.junit.jupiter.api.extension.ExtendWith}
+ */
+public class MTEExtension implements BeforeAllCallback, AfterAllCallback, ParameterResolver, TestInstancePostProcessor {
+
+    private final Map<Class<?>, ModuleTestingEnvironment> mteContexts = new HashMap<>();
+
+    @Override
+    public void afterAll(ExtensionContext context) throws Exception {
+        mteContexts.get(context.getRequiredTestClass()).tearDown();
+    }
+
+    @Override
+    public void beforeAll(ExtensionContext context) throws Exception {
+        Dependencies dependencies = context.getRequiredTestClass().getAnnotation(Dependencies.class);
+        UseWorldGenerator useWorldGenerator = context.getRequiredTestClass().getAnnotation(UseWorldGenerator.class);
+        ModuleTestingEnvironment mteContext = new ModuleTestingEnvironment();
+        if (dependencies != null) {
+            mteContext.setDependencies(Sets.newHashSet(dependencies.value()));
+        }
+        if (useWorldGenerator != null) {
+            mteContext.setWorldGeneratorUri(useWorldGenerator.value());
+        }
+        mteContext.setup();
+        mteContexts.put(context.getRequiredTestClass(), mteContext);
+    }
+
+    @Override
+    public boolean supportsParameter(ParameterContext parameterContext, ExtensionContext extensionContext) throws ParameterResolutionException {
+        ModuleTestingEnvironment mte = mteContexts.get(extensionContext.getRequiredTestClass());
+        return mte.getHostContext().get(parameterContext.getParameter().getType()) != null
+                || parameterContext.getParameter().getType().equals(ModuleTestingEnvironment.class);
+    }
+
+    @Override
+    public Object resolveParameter(ParameterContext parameterContext, ExtensionContext extensionContext) throws ParameterResolutionException {
+        ModuleTestingEnvironment mte = mteContexts.get(extensionContext.getRequiredTestClass());
+        Class<?> type = parameterContext.getParameter().getType();
+
+        return getDIInstance(mte, type);
+    }
+
+    private Object getDIInstance(ModuleTestingEnvironment mte, Class<?> type) {
+        if (type.equals(ModuleTestingEnvironment.class)) {
+            return mte;
+        }
+        return mte.getHostContext().get(type);
+    }
+
+    @Override
+    public void postProcessTestInstance(Object testInstance, ExtensionContext extensionContext) throws Exception {
+        ModuleTestingEnvironment mte = mteContexts.get(extensionContext.getRequiredTestClass());
+        List<IllegalAccessException> exceptionList = new LinkedList<>();
+        Arrays.stream(testInstance.getClass().getDeclaredFields())
+                .filter((field) -> field.getAnnotation(In.class) != null)
+                .peek((field) -> field.setAccessible(true))
+                .forEach((field) -> {
+                    Object candidateObject = getDIInstance(mte, field.getType());
+                    try {
+                        field.set(testInstance, candidateObject);
+                    } catch (IllegalAccessException e) {
+                        exceptionList.add(e);
+                    }
+                });
+        // It is tests, then it is legal ;)
+        if (!exceptionList.isEmpty()) {
+            throw new MultipleFailuresError("I cannot provide DI instances:", exceptionList);
+        }
+    }
+}

--- a/src/main/java/org/terasology/moduletestingenvironment/ModuleTestingEnvironment.java
+++ b/src/main/java/org/terasology/moduletestingenvironment/ModuleTestingEnvironment.java
@@ -15,6 +15,7 @@
  */
 package org.terasology.moduletestingenvironment;
 
+import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -22,6 +23,8 @@ import org.jboss.shrinkwrap.api.nio.file.ShrinkWrapFileSystems;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terasology.config.Config;
@@ -55,6 +58,7 @@ import org.terasology.world.RelevanceRegionComponent;
 import org.terasology.world.WorldProvider;
 
 import java.nio.file.FileSystem;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.function.Supplier;
@@ -140,6 +144,8 @@ import static org.mockito.Mockito.mock;
  */
 public class ModuleTestingEnvironment {
     private static final Logger logger = LoggerFactory.getLogger(ModuleTestingEnvironment.class);
+    private Set<String> dependencies = Sets.newHashSet("engine");
+    private String worldGeneratorUri = "moduletestingenvironment:dummy";
     private boolean doneLoading;
     private TerasologyEngine host;
     private Context hostContext;
@@ -153,6 +159,7 @@ public class ModuleTestingEnvironment {
      * @throws Exception
      */
     @Before
+    @BeforeEach
     public void setup() throws Exception {
         host = createHost();
         ScreenGrabber grabber = mock(ScreenGrabber.class);
@@ -166,6 +173,7 @@ public class ModuleTestingEnvironment {
      * Used to properly shut down and clean up a testing environment set up and started with {@link #setup()}.
      */
     @After
+    @AfterEach
     public void tearDown() {
         engines.forEach(TerasologyEngine::shutdown);
         engines.forEach(TerasologyEngine::cleanup);
@@ -180,7 +188,19 @@ public class ModuleTestingEnvironment {
      * @return The set of module names to load
      */
     public Set<String> getDependencies() {
-        return Sets.newHashSet("engine");
+        return dependencies;
+    }
+
+    /**
+     * Setting dependencies for using by {@link ModuleTestingEnvironment}.
+     *
+     * @param dependencies the set of module names to load
+     * @throws IllegalStateException if you try'd setWorldGeneratorUrl after {@link
+     *         ModuleTestingEnvironment#setup()}
+     */
+    void setDependencies(Set<String> dependencies) {
+        Preconditions.checkState(host == null, "You cannot set Dependencies after setup");
+        this.dependencies = dependencies;
     }
 
     /**
@@ -190,8 +210,21 @@ public class ModuleTestingEnvironment {
      * @return the uri of the desired world generator
      */
     public String getWorldGeneratorUri() {
-        return "moduletestingenvironment:dummy";
+        return worldGeneratorUri;
     }
+
+    /**
+     * Setting world generator for using by {@link ModuleTestingEnvironment}.
+     *
+     * @param worldGeneratorUri the uri of desired world generator
+     * @throws IllegalStateException if you try'd setWorldGeneratorUrl after {@link
+     *         ModuleTestingEnvironment#setup()}
+     */
+    void setWorldGeneratorUri(String worldGeneratorUri) {
+        Preconditions.checkState(host == null, "You cannot set Dependencies after setup");
+        this.worldGeneratorUri = worldGeneratorUri;
+    }
+
 
     /**
      * Creates a dummy entity with RelevanceRegion component to force a chunk's generation and availability. Blocks

--- a/src/main/java/org/terasology/moduletestingenvironment/extension/Dependencies.java
+++ b/src/main/java/org/terasology/moduletestingenvironment/extension/Dependencies.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2020 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.terasology.moduletestingenvironment.extension;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Dependencies {
+    /**
+     * Override this to change which modules must be loaded for the environment
+     *
+     * @return The set of module names to load
+     */
+    String[] value();
+}

--- a/src/main/java/org/terasology/moduletestingenvironment/extension/UseWorldGenerator.java
+++ b/src/main/java/org/terasology/moduletestingenvironment/extension/UseWorldGenerator.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2020 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.terasology.moduletestingenvironment.extension;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface UseWorldGenerator {
+
+    /**
+     * Override this to change which world generator to use. Defaults to a dummy generator that leaves all blocks as
+     * air
+     *
+     * @return the uri of the desired world generator
+     */
+    String value();
+}

--- a/src/test/java/org/terasology/moduletestingenvironment/AssetLoadingTest.java
+++ b/src/test/java/org/terasology/moduletestingenvironment/AssetLoadingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 MovingBlocks
+ * Copyright 2020 MovingBlocks
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,34 +15,37 @@
  */
 package org.terasology.moduletestingenvironment;
 
-import com.google.common.collect.Sets;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.terasology.assets.management.AssetManager;
 import org.terasology.entitySystem.prefab.Prefab;
+import org.terasology.moduletestingenvironment.extension.Dependencies;
+import org.terasology.registry.In;
 import org.terasology.world.block.Block;
 import org.terasology.world.block.BlockManager;
 
-import java.util.Set;
+import java.util.Optional;
 
-public class AssetLoadingTest extends ModuleTestingEnvironment {
+@ExtendWith(MTEExtension.class)
+@Dependencies({"engine", "ModuleTestingEnvironment"})
+public class AssetLoadingTest {
 
-    @Override
-    public Set<String> getDependencies() {
-        return Sets.newHashSet("engine", "ModuleTestingEnvironment");
-    }
+    @In
+    private BlockManager blockManager;
+    @In
+    private AssetManager assetManager;
 
     @Test
     public void blockPrefabLoadingTest() {
-        Block block = getHostContext().get(BlockManager.class).getBlock("engine:air");
-        Assert.assertNotNull(block);
-        Assert.assertEquals(0, block.getHardness());
-        Assert.assertEquals("Air", block.getDisplayName());
+        Block block = blockManager.getBlock("engine:air");
+        Assertions.assertNotNull(block);
+        Assertions.assertEquals(0, block.getHardness());
+        Assertions.assertEquals("Air", block.getDisplayName());
     }
 
     @Test
     public void simpleLoadingTest() {
-        AssetManager assetManager = getHostContext().get(AssetManager.class);
-        Assert.assertNotNull(assetManager.getAsset("engine:test", Prefab.class).get());
+        Assertions.assertNotEquals(assetManager.getAsset("engine:test", Prefab.class), Optional.empty());
     }
 }

--- a/src/test/java/org/terasology/moduletestingenvironment/ClientConnectionTest.java
+++ b/src/test/java/org/terasology/moduletestingenvironment/ClientConnectionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 MovingBlocks
+ * Copyright 2020 MovingBlocks
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,29 +15,28 @@
  */
 package org.terasology.moduletestingenvironment;
 
-import com.google.common.collect.Sets;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.terasology.context.Context;
 import org.terasology.engine.TerasologyEngine;
 import org.terasology.engine.modes.StateIngame;
+import org.terasology.moduletestingenvironment.extension.Dependencies;
 
 import java.util.List;
-import java.util.Set;
 
-public class ClientConnectionTest extends ModuleTestingEnvironment {
-    @Override
-    public Set<String> getDependencies() {
-        return Sets.newHashSet("engine", "ModuleTestingEnvironment");
-    }
+@ExtendWith(MTEExtension.class)
+@Dependencies({"engine", "ModuleTestingEnvironment"})
+public class ClientConnectionTest {
 
     @Test
-    public void testClientConnection() {
-        Context clientContext = createClient();
-        List<TerasologyEngine> engines = getEngines();
-        Assert.assertEquals(2, engines.size());
-        for(TerasologyEngine engine : engines) {
-            Assert.assertEquals(StateIngame.class, engine.getState().getClass());
-        }
+    public void testClientConnection(ModuleTestingEnvironment mte) {
+        Context clientContext = mte.createClient();
+        List<TerasologyEngine> engines = mte.getEngines();
+        Assertions.assertEquals(2, engines.size());
+        Assertions.assertAll(engines
+                .stream()
+                .map((engine) ->
+                        () -> Assertions.assertEquals(StateIngame.class, engine.getState().getClass())));
     }
 }

--- a/src/test/java/org/terasology/moduletestingenvironment/ComponentSystemTest.java
+++ b/src/test/java/org/terasology/moduletestingenvironment/ComponentSystemTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 MovingBlocks
+ * Copyright 2020 MovingBlocks
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,33 +15,26 @@
  */
 package org.terasology.moduletestingenvironment;
 
-import com.google.common.collect.Sets;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.terasology.entitySystem.entity.EntityManager;
 import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.moduletestingenvironment.extension.Dependencies;
 import org.terasology.moduletestingenvironment.fixtures.DummyComponent;
 import org.terasology.moduletestingenvironment.fixtures.DummyEvent;
+import org.terasology.registry.In;
 
-import java.util.Set;
-
-public class ComponentSystemTest extends ModuleTestingEnvironment {
-    EntityRef entity;
-
-    @Override
-    public Set<String> getDependencies() {
-        return Sets.newHashSet("engine", "ModuleTestingEnvironment");
-    }
-
-    @Before
-    public void before() {
-        entity = getHostContext().get(EntityManager.class).create(new DummyComponent());
-    }
+@ExtendWith(MTEExtension.class)
+@Dependencies({"engine", "ModuleTestingEnvironment"})
+public class ComponentSystemTest {
+    @In
+    private EntityManager entityManager;
 
     @Test
     public void simpleEventTest() {
+        EntityRef entity = entityManager.create(new DummyComponent());
         entity.send(new DummyEvent());
-        Assert.assertTrue(entity.getComponent(DummyComponent.class).dummy);
+        Assertions.assertTrue(entity.getComponent(DummyComponent.class).dummy);
     }
 }

--- a/src/test/java/org/terasology/moduletestingenvironment/WorldProviderTest.java
+++ b/src/test/java/org/terasology/moduletestingenvironment/WorldProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 MovingBlocks
+ * Copyright 2020 MovingBlocks
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,35 +15,36 @@
  */
 package org.terasology.moduletestingenvironment;
 
-import com.google.common.collect.Sets;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.terasology.math.geom.Vector3i;
+import org.terasology.moduletestingenvironment.extension.Dependencies;
+import org.terasology.registry.In;
 import org.terasology.world.WorldProvider;
 import org.terasology.world.block.BlockManager;
 
-import java.util.Set;
+@ExtendWith(MTEExtension.class)
+@Dependencies({"engine", "ModuleTestingEnvironment"})
+public class WorldProviderTest {
 
-public class WorldProviderTest extends ModuleTestingEnvironment {
-
-    @Override
-    public Set<String> getDependencies() {
-        return Sets.newHashSet("engine", "ModuleTestingEnvironment");
-    }
+    @In
+    WorldProvider worldProvider;
+    @In
+    BlockManager blockManager;
+    @In
+    ModuleTestingEnvironment moduleTestingEnvironment;
 
     @Test
     public void defaultWorldSetBlockTest() {
-        WorldProvider worldProvider = getHostContext().get(WorldProvider.class);
-        BlockManager blockManager = getHostContext().get(BlockManager.class);
-
-        forceAndWaitForGeneration(Vector3i.zero());
+        moduleTestingEnvironment.forceAndWaitForGeneration(Vector3i.zero());
 
         // this will change if the worldgenerator changes or the seed is altered, the main point is that this is a real
         // block type and not engine:unloaded
-        Assert.assertEquals("engine:air", worldProvider.getBlock(0, 0 ,0).getURI().toString());
+        Assertions.assertEquals("engine:air", worldProvider.getBlock(0, 0, 0).getURI().toString());
 
         // also verify that we can set and immediately get blocks from the worldprovider
         worldProvider.setBlock(Vector3i.zero(), blockManager.getBlock("engine:unloaded"));
-        Assert.assertEquals("engine:unloaded", worldProvider.getBlock(0, 0 ,0).getURI().toString());
+        Assertions.assertEquals("engine:unloaded", worldProvider.getBlock(0, 0, 0).getURI().toString());
     }
 }


### PR DESCRIPTION
Simple Junit 5 Extension for hold ModuleTestingEnvironment and provides DI via annotation or injection to methods/constructor parameters.
Provides injection by "host" now.

Futher possible some annotation for client's managers injection. 
