### PR TITLE
try loading installPath as a module (fixes #12)

### DIFF
--- a/module.txt
+++ b/module.txt
@@ -1,6 +1,6 @@
 {
     "id": "ModuleTestingEnvironment",
-    "version": "0.2.0",
+    "version": "0.2.1",
     "author": "The Terasology Foundation",
     "displayName": "Module Testing Environment",
     "description": "A test helper to instantiate a full headless TerasologyEngine instance.",


### PR DESCRIPTION
## How to test
Follow the reproduction steps in #12 . I also had to copy `buildSrc` to get the terasology-module gradle plugin loading, YMMV.

Next, go to your real Terasology checkout and disable javadoc publishing temporarily because the javadoc fails out the local maven publish tasks we're about to run. Edit `config/gradle/publish.gradle` and comment out this line:

```
//            artifact source: javadocJar, classifier: 'javadoc'
```

Then publish MTE with changes from this PR to mavenLocal from the real Terasology checkout:
```
Terasology on  develop [!] via ☕ v11.0.7 
❯ ./gradlew modules:ModuleTestingEnvironment:publishToMavenLocal
```

Then publish the engine with changes in https://github.com/MovingBlocks/Terasology/pull/4066
```
Terasology on  develop [!] via ☕ v11.0.7
❯ ./gradlew engine:publishToMavenLocal
```

Go back to your reproduction checkout of Health and run the tests:
```
Health on  develop [!?] via ☕ v11.0.7
❯ ./gradlew clean check
... snip ...
BlockTest > blockRegenTest FAILED
    java.lang.AssertionError at BlockTest.java:85

22 tests completed, 2 failed
... snip ...
```

Where you can see all of the tests run, 20 pass, and 2 fail (but with assertions instead of exceptions!)

## Rambling

This was a fun one!

Like the output says, the engine instance couldn't resolve the dependencies. In this first case, the dependency it was unable to resolve was the module itself.

Consider that modules are loaded from one of `homePath/modules`, `installPath/modules`, or the classpath (more on that later). So in a standalone directory of Health, it tries to load Health as the only specified dependency. It looks in `./modules` which is empty and says "I can't find the module Health".

Simple enough, MTE can solve this by hacking up a ModuleLoader and pointing it at installPath. For the IDE case, nothing changes and so it has no effect. For the standalone module case, the module is able to load itself!

Yet we're not quite done. We can load Health, but it has two dependencies: CoreAssets and ModuleTestingEnvironment. And those aren't in `./modules` either! Gradle sends them on the class path, so the classes are loaded successfully. But the Terasology module system doesn't know where those modules are. Fortunately, it already had logic to load modules from the classpath and just needed a little modernizing. See https://github.com/MovingBlocks/Terasology/pull/4066 for the details there.