### PR TITLE
Feature/remove shrinkwrap dependency

### DIFF
--- a/module.txt
+++ b/module.txt
@@ -1,6 +1,6 @@
 {
     "id": "ModuleTestingEnvironment",
-    "version": "0.2.0",
+    "version": "0.2.1",
     "author": "The Terasology Foundation",
     "displayName": "Module Testing Environment",
     "description": "A test helper to instantiate a full headless TerasologyEngine instance.",


### PR DESCRIPTION
(This PR is branched from https://github.com/Terasology/ModuleTestingEnvironment/pull/16)

Replaces Shrinkwrap usage with temporary directories. This lets us drop a dependency on jboss which was cargo culted from an early MTE prototype.

What I really wanted was an in-memory FS provider but couldn't find one in the current classpath. Mostly we're just creating directories anyway so the time spent in FS writes will be just milliseconds out of the ~30 second typical runtime of an MTE test.