### PR TITLE
feat: Allow to set component types for TestEventReceiver

### DIFF
--- a/src/main/java/org/terasology/moduletestingenvironment/TestEventReceiver.java
+++ b/src/main/java/org/terasology/moduletestingenvironment/TestEventReceiver.java
@@ -15,7 +15,9 @@
  */
 package org.terasology.moduletestingenvironment;
 
+import com.google.common.collect.Lists;
 import org.terasology.context.Context;
+import org.terasology.entitySystem.Component;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.entitySystem.entity.internal.EntityInfoComponent;
 import org.terasology.entitySystem.event.Event;
@@ -52,9 +54,18 @@ import java.util.function.BiConsumer;
  * });
  * }
  * </pre>
- *
- * You can automatically unregister your receiver using a try-with-resources block ({@code
- * TestEventReceiver} is {@link AutoCloseable}):
+ * Additionally, a list of required <emph>component types</emph> can be passed to the event receiver. This is equivalent
+ * to listing the components in the {@code ReceiveEvent(components = {...}} block of a regular event handler.
+ * <pre>
+ * {code
+ * TestEventReceiver receiver = new TestEventReceiver<>(context, DropItemEvent.class, (event, entity) -> {
+ *   // do something with the event or entity
+ * }, MagicItemComponent.class);
+ * }
+ * </pre>
+ * <p>
+ * You can automatically unregister your receiver using a try-with-resources block ({@code TestEventReceiver} is {@link
+ * AutoCloseable}):
  *
  * <pre>
  * {@literal
@@ -63,52 +74,67 @@ import java.util.function.BiConsumer;
  * }
  * }
  * </pre>
- *
- * Note that listeners are discarded with the rest of the engine between tests, so closing your receiver is only
- * useful if you need to stop handling events within a single test method.
+ * <p>
+ * Note that listeners are discarded with the rest of the engine between tests, so closing your receiver is only useful
+ * if you need to stop handling events within a single test method.
  */
-public class TestEventReceiver<T extends Event> implements AutoCloseable, EventReceiver<T>{
+public class TestEventReceiver<T extends Event> implements AutoCloseable, EventReceiver<T> {
+    private final EventSystem eventSystem;
+    private final Class<T> eventClass;
+    private final BiConsumer<T, EntityRef> handler;
 
-    private EventSystem eventSystem;
-    private Class<T> eventClass;
-    private List<EntityRef> entityRefs = new ArrayList<>();
-    private List<T> events = new ArrayList<>();
-    private BiConsumer<T, EntityRef> handler = (a, b)-> { };
+    private final List<EntityRef> entityRefs = new ArrayList<>();
+    private final List<T> events = new ArrayList<>();
 
     /**
      * Constructs a new {@code TestEventReceiver} and registers it to listen for events.
-     *
+     * <p>
+     * The following signature of a {@code TestEventReceiver} is equivalent to the event handler below:
      * <pre>
-     * {@literal
-     * TestEventReceiver receiver = new TestEventReceiver<>(context, DropItemEvent.class, (event, entity) -> {
+     * {@code
+     * TestEventReceiver receiver = new TestEventReceiver<>(context, MyEvent.class, (event, entity) -> {
      *   // do something with the event or entity
-     * });
+     * }, MyComponent.class);
+     *
+     * // ... corresponds to
+     *
+     * @ReceiveEvent(components = {MyComponent.class})
+     * public void handler(MyEvent event, EntityRef entity) {
+     *     // do something with the event or entity
+     * }
      * }
      * </pre>
      *
-     * @param context the context object for the test; this should probably be obtained through
-     *                {@link ModuleTestingEnvironment#getHostContext()} and is needed so we can
-     *                obtain an {@link EventSystem} instance to register our event handler.
-     * @param eventClass   the {@link Event} subclass to listen for
-     * @param handler an optional {@link BiConsumer} to fire when events are received.
+     * @param context the context object for the test; this should probably be obtained through {@link
+     *         ModuleTestingHelper#createClient()} and is needed so we can obtain an {@link EventSystem} instance to
+     *         register our event handler.
+     * @param eventClass the {@link Event} subclass to listen for
+     * @param handler an optional {@link BiConsumer} fired when events are received
+     * @param componentTypes list of component types that need to be present on the entity receiving the event
      */
-    public TestEventReceiver(Context context, Class<T> eventClass, BiConsumer<T, EntityRef> handler) {
-        this.handler = handler;
+    public TestEventReceiver(Context context, Class<T> eventClass, BiConsumer<T, EntityRef> handler, Class<?
+            extends Component>... componentTypes) {
         this.eventClass = eventClass;
+        this.handler = handler;
         eventSystem = context.get(EventSystem.class);
-        eventSystem.registerEventReceiver(this, eventClass, EntityInfoComponent.class);
+
+        Class<? extends Component>[] components =
+                Lists.asList(EntityInfoComponent.class, componentTypes).toArray(new Class[componentTypes.length + 1]);
+
+        eventSystem.registerEventReceiver(this, eventClass, components);
     }
 
     /**
-     * @see #TestEventReceiver(Context, Class, BiConsumer)
+     * @see #TestEventReceiver(Context, Class, BiConsumer, Class[])
      */
     public TestEventReceiver(Context context, Class<T> eventClass) {
-        this.eventClass = eventClass;
-        eventSystem = context.get(EventSystem.class);
-        eventSystem.registerEventReceiver(this, eventClass, EntityInfoComponent.class);
+        this(context, eventClass, (event, entity) -> {
+        });
     }
 
-    /** Unregisters this {@code TestEventReceiver} so it stops listening for events. */
+    /**
+     * Unregisters this {@code TestEventReceiver} so it stops listening for events.
+     */
     public void close() {
         eventSystem.unregisterEventReceiver(this, eventClass, EntityInfoComponent.class);
     }
@@ -116,11 +142,11 @@ public class TestEventReceiver<T extends Event> implements AutoCloseable, EventR
     /**
      * Returns a read-only view of the list of entities which are sent events.
      * <p>
-     * Note that entities appear in the order they received the events, and may appear multiple times.
-     * Each entity corresponds to the {@link #getEvents()} member with the same index.
+     * Note that entities appear in the order they received the events, and may appear multiple times. Each entity
+     * corresponds to the {@link #getEvents()} member with the same index.
      * <p>
-     * If the {@code TestEventReceiver} has not been {@linkplain #close() closed}, then this list will
-     * continue to be updated if further events occur.
+     * If the {@code TestEventReceiver} has not been {@linkplain #close() closed}, then this list will continue to be
+     * updated if further events occur.
      */
     public List<EntityRef> getEntityRefs() {
         return Collections.unmodifiableList(entityRefs);
@@ -129,8 +155,8 @@ public class TestEventReceiver<T extends Event> implements AutoCloseable, EventR
     /**
      * Returns a read-only view of the list of events.
      * <p>
-     * If the {@code TestEventReceiver} has not been {@linkplain #close() closed}, then this list will
-     * continue to be updated if further events occur.
+     * If the {@code TestEventReceiver} has not been {@linkplain #close() closed}, then this list will continue to be
+     * updated if further events occur.
      */
     public List<T> getEvents() {
         return Collections.unmodifiableList(events);
@@ -139,10 +165,9 @@ public class TestEventReceiver<T extends Event> implements AutoCloseable, EventR
     /**
      * Records the event.
      * <p>
-     * Note that this doesn't put the entity in an inventory or otherwise interfere with the event
-     * itself, but it does store a reference to the entity and event.  Consequently, the entity still exists in
-     * the world, and if other actors modify or destroy it, those changes would be reflected in the
-     * list of entityRefs.
+     * Note that this doesn't put the entity in an inventory or otherwise interfere with the event itself, but it does
+     * store a reference to the entity and event.  Consequently, the entity still exists in the world, and if other
+     * actors modify or destroy it, those changes would be reflected in the list of entityRefs.
      */
     public void onEvent(T event, EntityRef entity) {
         handler.accept(event, entity);


### PR DESCRIPTION
Solves #4

This change allows to pass additional varargs for component types to the `TestEventReceiver`. Passing no component types yields the same behavior as before.