### PR TITLE
add safety timeout and use game time for normal timeouts (fixes #21)

### DIFF
--- a/src/test/java/org/terasology/moduletestingenvironment/ExampleTest.java
+++ b/src/test/java/org/terasology/moduletestingenvironment/ExampleTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.terasology.context.Context;
+import org.terasology.engine.Time;
 import org.terasology.entitySystem.entity.EntityManager;
 import org.terasology.logic.players.LocalPlayer;
 import org.terasology.logic.players.event.ResetCameraEvent;
@@ -43,6 +44,8 @@ public class ExampleTest {
     @In
     private EntityManager entityManager;
     @In
+    private Time time;
+    @In
     private ModuleTestingHelper helper;
 
     @Test
@@ -56,8 +59,11 @@ public class ExampleTest {
         Assertions.assertEquals(2, Lists.newArrayList(entityManager.getEntitiesWith(ClientComponent.class)).size());
 
         // run while a condition is true or until a timeout passes
+        long expectedTime = time.getGameTimeInMs() + 1000;
         boolean timedOut = helper.runWhile(1000, ()-> true);
         Assertions.assertTrue(timedOut);
+        Assertions.assertTrue(time.getGameTimeInMs() >= expectedTime);
+        Assertions.assertTrue(time.getGameTimeInMs() < expectedTime + 100);
 
         // send an event to a client's local player just for fun
         clientContext1.get(LocalPlayer.class).getClientEntity().send(new ResetCameraEvent());


### PR DESCRIPTION
1. Reinterprets `timeoutMs` parameters in `run*` to mean game time.
2. Adds a new "safety timeout" concept to MTE, which defaults to 60 real world seconds.
3. Asserts false when the safety timeout is exceeded by a single `run*` invocation to loudly fail the affected test.

Users now get the following when the safety timeout is exceeded:

```
org.opentest4j.AssertionFailedError: MTE Safety timeout exceeded. See setSafetyTimeoutMs() ==> 
Expected :true
Actual   :false
```