### PR TITLE
remove unguaranteed assertion in example test

### DIFF
--- a/src/test/java/org/terasology/moduletestingenvironment/ExampleTest.java
+++ b/src/test/java/org/terasology/moduletestingenvironment/ExampleTest.java
@@ -64,7 +64,6 @@ public class ExampleTest {
         Assertions.assertTrue(timedOut);
         long currentTime = time.getGameTimeInMs();
         Assertions.assertTrue(currentTime >= expectedTime);
-        Assertions.assertTrue(currentTime < expectedTime + 100);
 
         // send an event to a client's local player just for fun
         clientContext1.get(LocalPlayer.class).getClientEntity().send(new ResetCameraEvent());


### PR DESCRIPTION
engine.tick() can run up to 2000ms later depending on performance