### PR TITLE
feat(JOML): migrate ModuleTestingEnvironment

### DIFF
--- a/src/main/java/org/terasology/moduletestingenvironment/MTEExtension.java
+++ b/src/main/java/org/terasology/moduletestingenvironment/MTEExtension.java
@@ -16,7 +16,6 @@
 
 package org.terasology.moduletestingenvironment;
 
-import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.extension.AfterAllCallback;
@@ -27,25 +26,15 @@ import org.junit.jupiter.api.extension.ParameterResolutionException;
 import org.junit.jupiter.api.extension.ParameterResolver;
 import org.junit.jupiter.api.extension.TestInstancePostProcessor;
 import org.opentest4j.MultipleFailuresError;
-import org.terasology.context.Context;
-import org.terasology.engine.TerasologyEngine;
-import org.terasology.engine.modes.StateMainMenu;
-import org.terasology.entitySystem.entity.EntityManager;
-import org.terasology.logic.location.LocationComponent;
-import org.terasology.math.geom.Vector3i;
 import org.terasology.moduletestingenvironment.extension.Dependencies;
 import org.terasology.moduletestingenvironment.extension.UseWorldGenerator;
 import org.terasology.registry.In;
-import org.terasology.rendering.opengl.ScreenGrabber;
-import org.terasology.world.RelevanceRegionComponent;
-import org.terasology.world.WorldProvider;
 
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Supplier;
 
 /**
  * Junit 5 Extension for using {@link ModuleTestingHelper} in your test.

--- a/src/main/java/org/terasology/moduletestingenvironment/ModuleTestingEnvironment.java
+++ b/src/main/java/org/terasology/moduletestingenvironment/ModuleTestingEnvironment.java
@@ -5,6 +5,9 @@ package org.terasology.moduletestingenvironment;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
+import org.joml.Vector3f;
+import org.joml.Vector3i;
+import org.joml.Vector3ic;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.jupiter.api.AfterEach;
@@ -37,7 +40,7 @@ import org.terasology.engine.subsystem.lwjgl.LwjglTimer;
 import org.terasology.engine.subsystem.openvr.OpenVRInput;
 import org.terasology.entitySystem.entity.EntityManager;
 import org.terasology.logic.location.LocationComponent;
-import org.terasology.math.geom.Vector3i;
+import org.terasology.math.JomlUtil;
 import org.terasology.module.Module;
 import org.terasology.module.ModuleLoader;
 import org.terasology.module.ModuleMetadataJsonAdapter;
@@ -235,7 +238,7 @@ public class ModuleTestingEnvironment {
      * @param blockPos the block position of the dummy entity. Only the chunk containing this position will be
      *         available
      */
-    public void forceAndWaitForGeneration(Vector3i blockPos) {
+    public void forceAndWaitForGeneration(Vector3ic blockPos) {
         WorldProvider worldProvider = hostContext.get(WorldProvider.class);
         if (worldProvider.isBlockRelevant(blockPos)) {
             return;
@@ -243,11 +246,11 @@ public class ModuleTestingEnvironment {
 
         // we need to add an entity with RegionRelevance in order to get a chunk generated
         LocationComponent locationComponent = new LocationComponent();
-        locationComponent.setWorldPosition(blockPos.toVector3f());
+        locationComponent.setWorldPosition(new Vector3f(blockPos));
 
         // relevance distance has to be at least 2 to get adjacent chunks in the cache, or else our main chunk will never be accessible
         RelevanceRegionComponent relevanceRegionComponent = new RelevanceRegionComponent();
-        relevanceRegionComponent.distance = new Vector3i(2, 2, 2);
+        relevanceRegionComponent.distance = JomlUtil.from(new Vector3i(2, 2, 2));
 
         hostContext.get(EntityManager.class).create(locationComponent, relevanceRegionComponent).setAlwaysRelevant(true);
 

--- a/src/test/java/org/terasology/moduletestingenvironment/DeprecationTest.java
+++ b/src/test/java/org/terasology/moduletestingenvironment/DeprecationTest.java
@@ -16,6 +16,8 @@
 package org.terasology.moduletestingenvironment;
 
 import com.google.common.collect.Lists;
+import org.joml.Vector3f;
+import org.joml.Vector3i;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -23,8 +25,6 @@ import org.terasology.context.Context;
 import org.terasology.entitySystem.entity.EntityManager;
 import org.terasology.logic.players.LocalPlayer;
 import org.terasology.logic.players.event.ResetCameraEvent;
-import org.terasology.math.geom.Vector3f;
-import org.terasology.math.geom.Vector3i;
 import org.terasology.moduletestingenvironment.extension.Dependencies;
 import org.terasology.network.ClientComponent;
 import org.terasology.registry.In;
@@ -66,10 +66,10 @@ public class DeprecationTest {
         clientContext1.get(LocalPlayer.class).getClientEntity().send(new ResetCameraEvent());
 
         // wait for a chunk to be generated
-        helper.forceAndWaitForGeneration(Vector3i.zero());
+        helper.forceAndWaitForGeneration(new Vector3i());
 
         // set a block's type and immediately read it back
-        worldProvider.setBlock(Vector3i.zero(), blockManager.getBlock("engine:air"));
-        Assertions.assertEquals("engine:air", worldProvider.getBlock(Vector3f.zero()).getURI().toString());
+        worldProvider.setBlock(new Vector3i(), blockManager.getBlock("engine:air"));
+        Assertions.assertEquals("engine:air", worldProvider.getBlock(new Vector3f()).getURI().toString());
     }
 }

--- a/src/test/java/org/terasology/moduletestingenvironment/ExampleTest.java
+++ b/src/test/java/org/terasology/moduletestingenvironment/ExampleTest.java
@@ -3,6 +3,7 @@
 package org.terasology.moduletestingenvironment;
 
 import com.google.common.collect.Lists;
+import org.joml.Vector3i;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -11,7 +12,6 @@ import org.terasology.engine.Time;
 import org.terasology.entitySystem.entity.EntityManager;
 import org.terasology.logic.players.LocalPlayer;
 import org.terasology.logic.players.event.ResetCameraEvent;
-import org.terasology.math.geom.Vector3i;
 import org.terasology.moduletestingenvironment.extension.Dependencies;
 import org.terasology.network.ClientComponent;
 import org.terasology.registry.In;
@@ -71,7 +71,7 @@ public class ExampleTest {
     @Test
     public void testWorldProvider() {
         // wait for a chunk to be generated
-        helper.forceAndWaitForGeneration(Vector3i.zero());
+        helper.forceAndWaitForGeneration(new Vector3i());
 
         // set a block's type and immediately read it back
         worldProvider.setBlock(new org.joml.Vector3i(), blockManager.getBlock("engine:air"));

--- a/src/test/java/org/terasology/moduletestingenvironment/WorldProviderTest.java
+++ b/src/test/java/org/terasology/moduletestingenvironment/WorldProviderTest.java
@@ -15,10 +15,10 @@
  */
 package org.terasology.moduletestingenvironment;
 
+import org.joml.Vector3i;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.terasology.math.geom.Vector3i;
 import org.terasology.moduletestingenvironment.extension.Dependencies;
 import org.terasology.registry.In;
 import org.terasology.world.WorldProvider;
@@ -37,14 +37,14 @@ public class WorldProviderTest {
 
     @Test
     public void defaultWorldSetBlockTest() {
-        helper.forceAndWaitForGeneration(Vector3i.zero());
+        helper.forceAndWaitForGeneration(new Vector3i());
 
         // this will change if the worldgenerator changes or the seed is altered, the main point is that this is a real
         // block type and not engine:unloaded
         Assertions.assertEquals("engine:air", worldProvider.getBlock(0, 0, 0).getURI().toString());
 
         // also verify that we can set and immediately get blocks from the worldprovider
-        worldProvider.setBlock(Vector3i.zero(), blockManager.getBlock("engine:unloaded"));
+        worldProvider.setBlock(new Vector3i(), blockManager.getBlock("engine:unloaded"));
         Assertions.assertEquals("engine:unloaded", worldProvider.getBlock(0, 0, 0).getURI().toString());
     }
 }


### PR DESCRIPTION
- [x] https://github.com/Terasology/BlockDetector/pull/7
- [ ] https://github.com/Terasology/Health/pull/59
- [x] https://github.com/Terasology/ItemPipes/pull/29
- [x] https://github.com/Terasology/SimpleFarming/pull/104
- [ ] https://github.com/Terasology/Rails/pull/68

`for m in ModuleTestingEnvironment BlockDetector Health ItemPipes Rails SimpleFarming; do pushd modules/$m; git checkout -b joml/migrate-mte; popd; done`