### PR TITLE
feat: use logback to filter log output

### DIFF
--- a/src/main/java/org/terasology/moduletestingenvironment/MTEExtension.java
+++ b/src/main/java/org/terasology/moduletestingenvironment/MTEExtension.java
@@ -16,7 +16,6 @@ import org.junit.jupiter.api.extension.ParameterContext;
 import org.junit.jupiter.api.extension.ParameterResolutionException;
 import org.junit.jupiter.api.extension.ParameterResolver;
 import org.junit.jupiter.api.extension.TestInstancePostProcessor;
-import org.opentest4j.IncompleteExecutionException;
 import org.opentest4j.MultipleFailuresError;
 import org.slf4j.LoggerFactory;
 import org.terasology.moduletestingenvironment.extension.Dependencies;
@@ -160,13 +159,13 @@ public class MTEExtension implements BeforeAllCallback, AfterAllCallback, Parame
         cfg.setContext(context);
         try (InputStream i = getClass().getResourceAsStream(LOGBACK_RESOURCE)) {
             if (i == null) {
-                throw new IncompleteExecutionException("Failed to find " + LOGBACK_RESOURCE);
+                throw new RuntimeException("Failed to find " + LOGBACK_RESOURCE);
             }
             cfg.doConfigure(i);
         } catch (IOException e) {
-            throw new IncompleteExecutionException("Error reading " + LOGBACK_RESOURCE, e);
+            throw new RuntimeException("Error reading " + LOGBACK_RESOURCE, e);
         } catch (JoranException e) {
-            throw new IncompleteExecutionException("Error during logger configuration", e);
+            throw new RuntimeException("Error during logger configuration", e);
         } finally {
             StatusPrinter.printInCaseOfErrorsOrWarnings(context);
         }

--- a/src/main/java/org/terasology/moduletestingenvironment/ModuleTestingEnvironment.java
+++ b/src/main/java/org/terasology/moduletestingenvironment/ModuleTestingEnvironment.java
@@ -1,4 +1,4 @@
-// Copyright 2020 The Terasology Foundation
+// Copyright 2021 The Terasology Foundation
 // SPDX-License-Identifier: Apache-2.0
 package org.terasology.moduletestingenvironment;
 
@@ -131,7 +131,7 @@ import static org.mockito.Mockito.mock;
  *
  * @Test
  * public void someTest() {
- * 	   Context hostContext = context.getHostContext();
+ *     Context hostContext = context.getHostContext();
  *     EntityManager entityManager = hostContext.get(EntityManager.class);
  *     // ...
  * }

--- a/src/main/java/org/terasology/moduletestingenvironment/TestingStateHeadlessSetup.java
+++ b/src/main/java/org/terasology/moduletestingenvironment/TestingStateHeadlessSetup.java
@@ -1,25 +1,10 @@
-/*
- * Copyright 2017 MovingBlocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2021 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
 package org.terasology.moduletestingenvironment;
 
 import com.google.common.collect.Sets;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.terasology.config.Config;
-import org.terasology.config.ModuleConfig;
 import org.terasology.engine.SimpleUri;
 import org.terasology.engine.TerasologyConstants;
 import org.terasology.engine.module.ModuleManager;
@@ -38,9 +23,9 @@ import java.util.Collection;
 import java.util.Set;
 
 public class TestingStateHeadlessSetup extends StateHeadlessSetup {
-    private static Logger logger = LoggerFactory.getLogger(TestingStateHeadlessSetup.class);
-    private Collection<String> dependencies;
-    private String worldGeneratorUri;
+    private static final Logger logger = LoggerFactory.getLogger(TestingStateHeadlessSetup.class);
+    private final Collection<String> dependencies;
+    private final String worldGeneratorUri;
     public TestingStateHeadlessSetup(Collection<String> dependencies, String worldGeneratorUri) {
         this.dependencies = dependencies;
         this.worldGeneratorUri = worldGeneratorUri;
@@ -56,7 +41,7 @@ public class TestingStateHeadlessSetup extends StateHeadlessSetup {
         DependencyResolver resolver = new DependencyResolver(CoreRegistry.get(ModuleManager.class).getRegistry());
 
         Set<Name> dependencyNames = Sets.newHashSet();
-        for(String moduleName : dependencies) {
+        for (String moduleName : dependencies) {
             logger.warn("Adding dependencies for {}", moduleName);
             dependencyNames.add(new Name(moduleName));
             recursivelyAddModuleDependencies(dependencyNames, new Name(moduleName));

--- a/src/main/resources/org/terasology/moduletestingenvironment/default-logback.xml
+++ b/src/main/resources/org/terasology/moduletestingenvironment/default-logback.xml
@@ -1,0 +1,23 @@
+<!-- Copyright 2021 The Terasology Foundation -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+<configuration>
+
+  <!-- Report all changes to this configuration on System.out -->
+  <statusListener class="ch.qos.logback.core.status.OnConsoleStatusListener" />
+
+  <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+    <!-- encoders are assigned the type PatternLayoutEncoder by default -->
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <root level="${logOverrideLevel:-debug}">
+    <appender-ref ref="CONSOLE" />
+  </root>
+
+  <logger name="org.terasology" level="${logOverrideLevel:-info}" />
+  <logger name="org.reflections.Reflections" level="${logOverrideLevel:-warn}" />
+
+</configuration>

--- a/src/main/resources/org/terasology/moduletestingenvironment/default-logback.xml
+++ b/src/main/resources/org/terasology/moduletestingenvironment/default-logback.xml
@@ -11,13 +11,28 @@
     <encoder>
       <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
     </encoder>
+
+    <filter class="ch.qos.logback.core.filter.EvaluatorFilter">
+      <evaluator>
+        <matcher>
+          <Name>reflectionsEmpty</Name>
+          <!-- filter out odd numbered statements -->
+          <regex>given scan urls are empty</regex>
+        </matcher>
+
+        <expression>reflectionsEmpty.matches(message)</expression>
+      </evaluator>
+      <OnMismatch>NEUTRAL</OnMismatch>
+      <OnMatch>DENY</OnMatch>
+    </filter>
   </appender>
 
-  <root level="${logOverrideLevel:-debug}">
+  <root level="${logOverrideLevel:-info}">
     <appender-ref ref="CONSOLE" />
   </root>
 
   <logger name="org.terasology" level="${logOverrideLevel:-info}" />
+  <logger name="org.terasology.i18n" level="warn" />
   <logger name="org.reflections.Reflections" level="${logOverrideLevel:-warn}" />
 
 </configuration>

--- a/src/test/java/org/terasology/moduletestingenvironment/IsolatedEngineTest.java
+++ b/src/test/java/org/terasology/moduletestingenvironment/IsolatedEngineTest.java
@@ -1,10 +1,9 @@
-// Copyright 2020 The Terasology Foundation
+// Copyright 2021 The Terasology Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 package org.terasology.moduletestingenvironment;
 
 import com.google.common.collect.Sets;
-import org.junit.Assert;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -16,6 +15,9 @@ import org.terasology.moduletestingenvironment.fixtures.DummyEvent;
 import org.terasology.registry.In;
 
 import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ExtendWith(IsolatedMTEExtension.class)
 @Dependencies({"engine", "ModuleTestingEnvironment"})
@@ -34,19 +36,19 @@ public class IsolatedEngineTest {
     @Test
     public void someTest() {
         // make sure we don't reuse the EntityManager
-        Assert.assertFalse(entityManagerSet.contains(entityManager));
+        assertFalse(entityManagerSet.contains(entityManager));
         entityManagerSet.add(entityManager);
 
         entity.send(new DummyEvent());
-        Assert.assertTrue(entity.getComponent(DummyComponent.class).dummy);
+        assertTrue(entity.getComponent(DummyComponent.class).dummy);
     }
 
     @Test
     public void someOtherTest() {
         // make sure we don't reuse the EntityManager
-        Assert.assertFalse(entityManagerSet.contains(entityManager));
+        assertFalse(entityManagerSet.contains(entityManager));
         entityManagerSet.add(entityManager);
 
-        Assert.assertFalse(entity.getComponent(DummyComponent.class).dummy);
+        assertFalse(entity.getComponent(DummyComponent.class).dummy);
     }
 }


### PR DESCRIPTION
This applies a logback configuration file (originally copied from `engine-test`) to all MTE tests.

It probably makes a mess of things if your test runner already had some other logback configuration, but I don't think we have any such testing environments.

Depends on https://github.com/MovingBlocks/Terasology/pull/4477 to change MTE's dependencies.