### PR TITLE
fix: fixes module resolution error

### DIFF
--- a/src/main/java/org/terasology/moduletestingenvironment/TestingStateHeadlessSetup.java
+++ b/src/main/java/org/terasology/moduletestingenvironment/TestingStateHeadlessSetup.java
@@ -10,7 +10,6 @@ import org.terasology.engine.TerasologyConstants;
 import org.terasology.engine.module.ModuleManager;
 import org.terasology.engine.subsystem.headless.mode.StateHeadlessSetup;
 import org.terasology.game.GameManifest;
-import org.terasology.module.DependencyInfo;
 import org.terasology.module.DependencyResolver;
 import org.terasology.module.Module;
 import org.terasology.module.ResolutionResult;
@@ -33,7 +32,6 @@ public class TestingStateHeadlessSetup extends StateHeadlessSetup {
 
     @Override
     public GameManifest createGameManifest() {
-
         GameManifest gameManifest = new GameManifest();
 
         gameManifest.setTitle("testworld");
@@ -42,9 +40,8 @@ public class TestingStateHeadlessSetup extends StateHeadlessSetup {
 
         Set<Name> dependencyNames = Sets.newHashSet();
         for (String moduleName : dependencies) {
-            logger.warn("Adding dependencies for {}", moduleName);
+            logger.info("Adding dependency {}", moduleName);
             dependencyNames.add(new Name(moduleName));
-            recursivelyAddModuleDependencies(dependencyNames, new Name(moduleName));
         }
 
         ResolutionResult result = resolver.resolve(dependencyNames);
@@ -62,16 +59,5 @@ public class TestingStateHeadlessSetup extends StateHeadlessSetup {
                 (long) (WorldTime.DAY_LENGTH * timeOffset), new SimpleUri(worldGeneratorUri));
         gameManifest.addWorld(worldInfo);
         return gameManifest;
-    }
-
-    private void recursivelyAddModuleDependencies(Set<Name> modules, Name moduleName) {
-        Module module = CoreRegistry.get(ModuleManager.class).getRegistry().getLatestModuleVersion(moduleName);
-        if (module != null) {
-            for (DependencyInfo dependencyInfo : module.getMetadata().getDependencies()) {
-                logger.warn("Adding dependency {}", dependencyInfo.getId());
-                modules.add(dependencyInfo.getId());
-                recursivelyAddModuleDependencies(modules, dependencyInfo.getId());
-            }
-        }
     }
 }

--- a/src/main/java/org/terasology/moduletestingenvironment/TestingStateHeadlessSetup.java
+++ b/src/main/java/org/terasology/moduletestingenvironment/TestingStateHeadlessSetup.java
@@ -49,11 +49,11 @@ public class TestingStateHeadlessSetup extends StateHeadlessSetup {
 
         ResolutionResult result = resolver.resolve(dependencyNames);
         if (!result.isSuccess()) {
-            logger.warn("Unable to resolve modules: {}", dependencyNames);
+            logger.error("Unable to resolve modules: {}", dependencyNames);
         }
 
         for (Module module : result.getModules()) {
-            logger.warn("Loading module {} {}", module.getId(), module.getVersion());
+            logger.info("Loading module {} {}", module.getId(), module.getVersion());
             gameManifest.addModule(module.getId(), module.getVersion());
         }
 

--- a/src/main/java/org/terasology/moduletestingenvironment/TestingStateHeadlessSetup.java
+++ b/src/main/java/org/terasology/moduletestingenvironment/TestingStateHeadlessSetup.java
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.terasology.moduletestingenvironment;
 
-import com.google.common.collect.Sets;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terasology.engine.SimpleUri;
@@ -20,6 +19,7 @@ import org.terasology.world.time.WorldTime;
 
 import java.util.Collection;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 public class TestingStateHeadlessSetup extends StateHeadlessSetup {
     private static final Logger logger = LoggerFactory.getLogger(TestingStateHeadlessSetup.class);
@@ -38,11 +38,8 @@ public class TestingStateHeadlessSetup extends StateHeadlessSetup {
         gameManifest.setSeed("seed");
         DependencyResolver resolver = new DependencyResolver(CoreRegistry.get(ModuleManager.class).getRegistry());
 
-        Set<Name> dependencyNames = Sets.newHashSet();
-        for (String moduleName : dependencies) {
-            logger.info("Adding dependency {}", moduleName);
-            dependencyNames.add(new Name(moduleName));
-        }
+        Set<Name> dependencyNames = dependencies.stream().map(Name::new).collect(Collectors.toSet());
+        logger.info("Building manifest for module dependencies: {}", dependencyNames);
 
         ResolutionResult result = resolver.resolve(dependencyNames);
         if (!result.isSuccess()) {

--- a/src/test/java/org/terasology/moduletestingenvironment/ReuseEngineTest.java
+++ b/src/test/java/org/terasology/moduletestingenvironment/ReuseEngineTest.java
@@ -1,23 +1,9 @@
-/*
- * Copyright 2020 MovingBlocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2021 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
 
 package org.terasology.moduletestingenvironment;
 
 import com.google.common.collect.Sets;
-import org.junit.Assert;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -28,6 +14,8 @@ import org.terasology.moduletestingenvironment.fixtures.DummyComponent;
 import org.terasology.moduletestingenvironment.fixtures.DummyEvent;
 
 import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ReuseEngineTest {
     private static ModuleTestingHelper helper;
@@ -61,11 +49,11 @@ public class ReuseEngineTest {
     @Test
     public void someTest() {
         entity.send(new DummyEvent());
-        Assert.assertTrue(entity.getComponent(DummyComponent.class).dummy);
+        assertTrue(entity.getComponent(DummyComponent.class).dummy);
     }
 
     @Test
     public void someOtherTest() {
-        Assert.assertTrue(entity.hasComponent(DummyComponent.class));
+        assertTrue(entity.hasComponent(DummyComponent.class));
     }
 }


### PR DESCRIPTION
For errors like this:

```
java.lang.IllegalStateException: Modules only available if resolution was successful
	at com.google.common.base.Preconditions.checkState(Preconditions.java:459)
	at org.terasology.module.ResolutionResult.getModules(ResolutionResult.java:47)
```

e.g. http://jenkins.terasology.io/teraorg/job/Terasology/job/Modules/view/Omega/job/T/job/Tasks/job/develop/16/testReport/junit/org.terasology.tasks.persistence/TaskGraphTypeHandlerTest/testDeserialize__/