### PR TITLE
feat: load modules from classpath (for dependencies)

### DIFF
--- a/src/main/java/org/terasology/moduletestingenvironment/ModuleLoadingStuff.java
+++ b/src/main/java/org/terasology/moduletestingenvironment/ModuleLoadingStuff.java
@@ -48,8 +48,11 @@ public class ModuleLoadingStuff {
         Stream<Path> allClassPaths = Arrays.stream(
                 System.getProperty("java.class.path").split(System.getProperty("path.separator", ":"))
         ).map(Paths::get).filter(path -> path.toFile().exists());
+
+        // Some of the entries may be things in the `modules/` directory of a Terasology workspace,
+        // in which case the standard ModuleManager will handle them and we don't need to.
         Stream<Path> pathsOutsideModulesDirectory = allClassPaths.filter(classPath -> pathManager.getModulePaths().stream().anyMatch(
-                other -> !classPath.startsWith(other)
+                modulesPath -> !classPath.startsWith(modulesPath)
         ));
         List<Path> classPaths = pathsOutsideModulesDirectory.collect(Collectors.toList());
 

--- a/src/main/java/org/terasology/moduletestingenvironment/ModuleLoadingStuff.java
+++ b/src/main/java/org/terasology/moduletestingenvironment/ModuleLoadingStuff.java
@@ -1,0 +1,87 @@
+// Copyright 2021 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+package org.terasology.moduletestingenvironment;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.terasology.engine.TerasologyConstants;
+import org.terasology.engine.TerasologyEngine;
+import org.terasology.engine.module.ClasspathSupportingModuleLoader;
+import org.terasology.engine.module.ModuleManager;
+import org.terasology.engine.paths.PathManager;
+import org.terasology.module.Module;
+import org.terasology.module.ModuleLoader;
+import org.terasology.module.ModuleMetadataJsonAdapter;
+import org.terasology.module.ModuleRegistry;
+import org.terasology.utilities.Jvm;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class ModuleLoadingStuff {
+    private static final Logger logger = LoggerFactory.getLogger(ModuleLoadingStuff.class);
+
+    private static ModuleRegistry registry;
+    private static ModuleLoader classpathLoader;
+    private static PathManager pathManager;
+
+    public ModuleLoadingStuff(TerasologyEngine engine) {
+        ModuleManager manager = engine.getFromEngineContext(ModuleManager.class);
+        pathManager = PathManager.getInstance();
+        registry = manager.getRegistry();
+        ModuleMetadataJsonAdapter metadataReader = manager.getModuleMetadataReader();
+        classpathLoader = new ClasspathSupportingModuleLoader(metadataReader, true, true);
+        classpathLoader.setModuleInfoPath(TerasologyConstants.MODULE_INFO_FILENAME);
+
+    }
+
+    void loadModulesFromClasspath() {
+        logger.debug("loadModulesFromClassPath with classpath:");
+        Jvm.logClasspath(logger);
+
+        Stream<Path> allClassPaths = Arrays.stream(
+                System.getProperty("java.class.path").split(System.getProperty("path.separator", ":"))
+        ).map(Paths::get).filter(path -> path.toFile().exists());
+        Stream<Path> pathsOutsideModulesDirectory = allClassPaths.filter(classPath -> pathManager.getModulePaths().stream().anyMatch(
+                other -> !classPath.startsWith(other)
+        ));
+        List<Path> classPaths = pathsOutsideModulesDirectory.collect(Collectors.toList());
+
+        // I thought I'd make the ClasspathSupporting stuff in the shape of a ModuleLoader
+        // so I could use it with the existing ModulePathScanner, but no. The inputs to that
+        // are the _parent directories_ of what we have.
+        for (Path path : classPaths) {
+            attemptToLoadModule(path);
+        }
+    }
+
+    public void attemptToLoadModule(Path path) {
+        // The conditions here mirror those of org.terasology.module.ModulePathScanner.loadModule
+
+        Module module;
+        try {
+            module = classpathLoader.load(path);
+        } catch (IOException e) {
+            logger.error("Failed to load classpath module {}", path, e);
+            return;
+        }
+
+        if (module == null) {
+            return;
+        }
+
+        boolean isNew = registry.add(module);
+        if (isNew) {
+            logger.info("Discovered module: {} on classpath as {}", module, path.getFileName());
+        } else {
+            logger.warn("Discovered duplicate module: {}-{}, skipping {}",
+                    module.getId(), module.getVersion(), path);
+        }
+    }
+}

--- a/src/main/java/org/terasology/moduletestingenvironment/ModuleTestingEnvironment.java
+++ b/src/main/java/org/terasology/moduletestingenvironment/ModuleTestingEnvironment.java
@@ -317,7 +317,7 @@ public class ModuleTestingEnvironment {
      *
      * @return the created client's context object
      */
-    public Context createClient() {
+    public Context createClient() throws IOException {
         TerasologyEngine terasologyEngine = createHeadlessEngine();
         terasologyEngine.getFromEngineContext(Config.class).getRendering().setViewDistance(ViewDistance.LEGALLY_BLIND);
 
@@ -375,7 +375,7 @@ public class ModuleTestingEnvironment {
         this.safetyTimeoutMs = safetyTimeoutMs;
     }
 
-    private TerasologyEngine createHeadlessEngine() {
+    private TerasologyEngine createHeadlessEngine() throws IOException {
         TerasologyEngineBuilder terasologyEngineBuilder = new TerasologyEngineBuilder();
         terasologyEngineBuilder
                 .add(new HeadlessGraphics())
@@ -386,7 +386,7 @@ public class ModuleTestingEnvironment {
         return createEngine(terasologyEngineBuilder);
     }
 
-    private TerasologyEngine createHeadedEngine() {
+    private TerasologyEngine createHeadedEngine() throws IOException {
         EngineSubsystem audio = new LwjglAudio();
         TerasologyEngineBuilder terasologyEngineBuilder = new TerasologyEngineBuilder()
                 .add(audio)
@@ -398,19 +398,15 @@ public class ModuleTestingEnvironment {
         return createEngine(terasologyEngineBuilder);
     }
 
-    private TerasologyEngine createEngine(TerasologyEngineBuilder terasologyEngineBuilder) {
+    private TerasologyEngine createEngine(TerasologyEngineBuilder terasologyEngineBuilder) throws IOException {
         // create temporary home paths so the MTE engines don't overwrite config/save files in your real home path
-        try {
-            Path path = Files.createTempDirectory("terasology-mte-engine");
-            PathManager.getInstance().useOverrideHomePath(path);
-            logger.info("Created temporary engine home path");
+        Path path = Files.createTempDirectory("terasology-mte-engine");
+        PathManager pathManager = PathManager.getInstance();
+        pathManager.useOverrideHomePath(path);
+        logger.info("Created temporary engine home path: {}", path);
 
-            // JVM will delete these on normal termination but not exceptions.
-            path.toFile().deleteOnExit();
-        } catch (Exception e) {
-            logger.warn("Exception creating temporary home path for engine: ", e);
-            return null;
-        }
+        // JVM will delete these on normal termination but not exceptions.
+        path.toFile().deleteOnExit();
 
         TerasologyEngine terasologyEngine = terasologyEngineBuilder.build();
         terasologyEngine.initialize();
@@ -458,7 +454,7 @@ public class ModuleTestingEnvironment {
         }
     }
 
-    private TerasologyEngine createHost() {
+    private TerasologyEngine createHost() throws IOException {
         TerasologyEngine terasologyEngine = createHeadlessEngine();
         terasologyEngine.getFromEngineContext(Config.class).getSystem().setWriteSaveGamesEnabled(false);
         terasologyEngine.subscribeToStateChange(new HeadlessStateChangeListener(terasologyEngine));

--- a/src/main/java/org/terasology/moduletestingenvironment/ModuleTestingEnvironment.java
+++ b/src/main/java/org/terasology/moduletestingenvironment/ModuleTestingEnvironment.java
@@ -413,7 +413,12 @@ public class ModuleTestingEnvironment {
 
         TerasologyEngine terasologyEngine = terasologyEngineBuilder.build();
         terasologyEngine.initialize();
-        registerCurrentDirectoryIfModule(terasologyEngine);
+
+        ModuleLoadingStuff moduleStuff = new ModuleLoadingStuff(terasologyEngine);
+        moduleStuff.loadModulesFromClasspath();
+        // does `loadModulesFromClasspath` make `registerCurrentDirectoryModule` redundant?
+        //
+        // registerCurrentDirectoryIfModule(terasologyEngine);
 
         engines.add(terasologyEngine);
         return terasologyEngine;

--- a/src/main/java/org/terasology/moduletestingenvironment/TestingStateHeadlessSetup.java
+++ b/src/main/java/org/terasology/moduletestingenvironment/TestingStateHeadlessSetup.java
@@ -41,6 +41,9 @@ public class TestingStateHeadlessSetup extends StateHeadlessSetup {
         Set<Name> dependencyNames = dependencies.stream().map(Name::new).collect(Collectors.toSet());
         logger.info("Building manifest for module dependencies: {}", dependencyNames);
 
+        // Include the MTE module to provide world generators and suchlike.
+        dependencyNames.add(new Name("ModuleTestingEnvironment"));
+
         ResolutionResult result = resolver.resolve(dependencyNames);
         if (!result.isSuccess()) {
             logger.error("Unable to resolve modules: {}", dependencyNames);

--- a/src/test/java/org/terasology/moduletestingenvironment/ClientConnectionTest.java
+++ b/src/test/java/org/terasology/moduletestingenvironment/ClientConnectionTest.java
@@ -1,18 +1,5 @@
-/*
- * Copyright 2020 MovingBlocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2021 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
 package org.terasology.moduletestingenvironment;
 
 import org.junit.jupiter.api.Assertions;
@@ -23,6 +10,7 @@ import org.terasology.engine.TerasologyEngine;
 import org.terasology.engine.modes.StateIngame;
 import org.terasology.moduletestingenvironment.extension.Dependencies;
 
+import java.io.IOException;
 import java.util.List;
 
 @ExtendWith(MTEExtension.class)
@@ -30,7 +18,7 @@ import java.util.List;
 public class ClientConnectionTest {
 
     @Test
-    public void testClientConnection(ModuleTestingHelper helper) {
+    public void testClientConnection(ModuleTestingHelper helper) throws IOException {
         Context clientContext = helper.createClient();
         List<TerasologyEngine> engines = helper.getEngines();
         Assertions.assertEquals(2, engines.size());

--- a/src/test/java/org/terasology/moduletestingenvironment/DeprecationTest.java
+++ b/src/test/java/org/terasology/moduletestingenvironment/DeprecationTest.java
@@ -1,18 +1,5 @@
-/*
- * Copyright 2020 MovingBlocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2021 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
 package org.terasology.moduletestingenvironment;
 
 import com.google.common.collect.Lists;
@@ -30,6 +17,8 @@ import org.terasology.network.ClientComponent;
 import org.terasology.registry.In;
 import org.terasology.world.WorldProvider;
 import org.terasology.world.block.BlockManager;
+
+import java.io.IOException;
 
 
 /**
@@ -49,7 +38,7 @@ public class DeprecationTest {
     private ModuleTestingEnvironment helper;
 
     @Test
-    public void testExample() {
+    public void testExample() throws IOException {
         // create some clients (the library connects them automatically)
         Context clientContext1 = helper.createClient();
         Context clientContext2 = helper.createClient();

--- a/src/test/java/org/terasology/moduletestingenvironment/ExampleTest.java
+++ b/src/test/java/org/terasology/moduletestingenvironment/ExampleTest.java
@@ -1,4 +1,4 @@
-// Copyright 2020 The Terasology Foundation
+// Copyright 2021 The Terasology Foundation
 // SPDX-License-Identifier: Apache-2.0
 package org.terasology.moduletestingenvironment;
 
@@ -18,6 +18,8 @@ import org.terasology.registry.In;
 import org.terasology.world.WorldProvider;
 import org.terasology.world.block.BlockManager;
 
+import java.io.IOException;
+
 
 @ExtendWith(MTEExtension.class)
 @Dependencies({"engine", "ModuleTestingEnvironment"})
@@ -35,7 +37,7 @@ public class ExampleTest {
     private ModuleTestingHelper helper;
 
     @Test
-    public void testClientConnection() {
+    public void testClientConnection() throws IOException {
         int currentClients = Lists.newArrayList(entityManager.getEntitiesWith(ClientComponent.class)).size();
 
         // create some clients (the library connects them automatically)
@@ -61,7 +63,7 @@ public class ExampleTest {
     }
 
     @Test
-    public void testSendEvent() {
+    public void testSendEvent() throws IOException {
         Context clientContext = helper.createClient();
 
         // send an event to a client's local player just for fun

--- a/src/test/java/org/terasology/moduletestingenvironment/delay/DelayManagerTest.java
+++ b/src/test/java/org/terasology/moduletestingenvironment/delay/DelayManagerTest.java
@@ -1,4 +1,4 @@
-// Copyright 2020 The Terasology Foundation
+// Copyright 2021 The Terasology Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 package org.terasology.moduletestingenvironment.delay;
@@ -21,6 +21,8 @@ import org.terasology.moduletestingenvironment.extension.Dependencies;
 import org.terasology.network.ClientComponent;
 import org.terasology.registry.In;
 
+import java.io.IOException;
+
 @ExtendWith(MTEExtension.class)
 @Dependencies({"engine", "ModuleTestingEnvironment"})
 public class DelayManagerTest {
@@ -36,7 +38,7 @@ public class DelayManagerTest {
     Time time;
 
     @Test
-    public void delayedActionIsTriggeredTest(ModuleTestingHelper helper) {
+    public void delayedActionIsTriggeredTest(ModuleTestingHelper helper) throws IOException {
         helper.createClient();
         helper.runWhile(() -> Lists.newArrayList(entityManager.getEntitiesWith(ClientComponent.class)).isEmpty());
 


### PR DESCRIPTION
If engine's ModuleManager doesn't load all modules on the classpath by default, how are MTE tests going to get their dependencies?

Companion to https://github.com/MovingBlocks/Terasology/pull/4543