### PR TITLE
fix: make sure the module under test depends on engine

### DIFF
--- a/src/main/java/org/terasology/moduletestingenvironment/ModuleTestingEnvironment.java
+++ b/src/main/java/org/terasology/moduletestingenvironment/ModuleTestingEnvironment.java
@@ -47,6 +47,7 @@ import org.terasology.engine.rendering.opengl.ScreenGrabber;
 import org.terasology.engine.rendering.world.viewDistance.ViewDistance;
 import org.terasology.engine.world.RelevanceRegionComponent;
 import org.terasology.engine.world.WorldProvider;
+import org.terasology.module.DependencyInfo;
 import org.terasology.module.Module;
 import org.terasology.module.ModuleLoader;
 import org.terasology.module.ModuleMetadataJsonAdapter;
@@ -436,6 +437,11 @@ public class ModuleTestingEnvironment {
         try {
             Module module = moduleLoader.load(installPath);
             if (module != null) {
+                if (module.getMetadata().getDependencyInfo(TerasologyConstants.ENGINE_MODULE) == null) {
+                    DependencyInfo engineDependency = new DependencyInfo();
+                    engineDependency.setId(TerasologyConstants.ENGINE_MODULE);
+                    module.getMetadata().getDependencies().add(engineDependency);
+                }
                 registry.add(module);
                 logger.info("Added install path as module: {}", installPath);
             } else {


### PR DESCRIPTION
There's redundancy with ModuleManager.ensureModulesDependOnEngine, but ModuleManager can't enforce this everyone goes around adding to its Registry directly.

Fixes #45, the failure to load built-in engine assets, I hope.