### PR TITLE
test: fix TestEventReceiverTest by giving target entity a DummyComponent

### DIFF
--- a/src/main/java/org/terasology/moduletestingenvironment/fixtures/DummySystem.java
+++ b/src/main/java/org/terasology/moduletestingenvironment/fixtures/DummySystem.java
@@ -26,8 +26,7 @@ import org.terasology.engine.registry.Share;
 @RegisterSystem(RegisterMode.AUTHORITY)
 public class DummySystem extends BaseComponentSystem {
     @ReceiveEvent
-    public void onDummyEvent(DummyEvent event, EntityRef entity) {
-        DummyComponent component = entity.getComponent(DummyComponent.class);
+    public void onDummyEvent(DummyEvent event, EntityRef entity, DummyComponent component) {
         component.dummy = true;
         entity.saveComponent(component);
     }

--- a/src/test/java/org/terasology/moduletestingenvironment/TestEventReceiverTest.java
+++ b/src/test/java/org/terasology/moduletestingenvironment/TestEventReceiverTest.java
@@ -107,7 +107,8 @@ public class TestEventReceiverTest {
      * @return the item
      */
     private EntityRef sendEvent() {
-        final EntityRef entityRef = getHostContext().get(EntityManager.class).create();
+        final EntityManager entityManager = getHostContext().get(EntityManager.class);
+        final EntityRef entityRef = entityManager.create(new DummyComponent());
         entityRef.send(new DummyEvent());
         return entityRef;
     }


### PR DESCRIPTION
By working on #55 we discovered that some of the tests are broken independent of any gestalt and module management issues. 

This PR fixes those tests (at least locally) by giving the target entity a `DummyComponent`, as is expected by `DummySystem`. 