### PR TITLE
chore: set scenario properties in the Config

### DIFF
--- a/src/main/java/org/terasology/moduletestingenvironment/TestingStateHeadlessSetup.java
+++ b/src/main/java/org/terasology/moduletestingenvironment/TestingStateHeadlessSetup.java
@@ -4,60 +4,69 @@ package org.terasology.moduletestingenvironment;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.terasology.engine.config.Config;
+import org.terasology.engine.config.ModuleConfig;
+import org.terasology.engine.config.WorldGenerationConfig;
+import org.terasology.engine.core.GameEngine;
 import org.terasology.engine.core.SimpleUri;
 import org.terasology.engine.core.TerasologyConstants;
-import org.terasology.engine.core.module.ModuleManager;
+import org.terasology.engine.core.TerasologyEngine;
 import org.terasology.engine.core.subsystem.headless.mode.StateHeadlessSetup;
 import org.terasology.engine.game.GameManifest;
-import org.terasology.engine.registry.CoreRegistry;
-import org.terasology.engine.world.internal.WorldInfo;
 import org.terasology.engine.world.time.WorldTime;
-import org.terasology.gestalt.module.dependencyresolution.DependencyResolver;
-import org.terasology.gestalt.module.dependencyresolution.ResolutionResult;
 import org.terasology.gestalt.naming.Name;
-import org.terasology.gestalt.module.Module;
 
 import java.util.Collection;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 public class TestingStateHeadlessSetup extends StateHeadlessSetup {
     private static final Logger logger = LoggerFactory.getLogger(TestingStateHeadlessSetup.class);
+
+    static final Name MTE_MODULE_NAME = new Name("ModuleTestingEnvironment");
+    static final String WORLD_TITLE = "testworld";
+    static final String DEFAULT_SEED = "seed";
+
     private final Collection<String> dependencies;
-    private final String worldGeneratorUri;
+    private final SimpleUri worldGeneratorUri;
     public TestingStateHeadlessSetup(Collection<String> dependencies, String worldGeneratorUri) {
         this.dependencies = dependencies;
-        this.worldGeneratorUri = worldGeneratorUri;
+        this.worldGeneratorUri = new SimpleUri(worldGeneratorUri);
+        checkArgument(this.worldGeneratorUri.isValid(), "Not a valid URI `%s`", worldGeneratorUri);
+    }
+
+    void configForTest(Config config) {
+        Set<Name> dependencyNames = dependencies.stream().map(Name::new).collect(Collectors.toSet());
+
+        // Include the MTE module to provide world generators and suchlike.
+        dependencyNames.add(MTE_MODULE_NAME);
+
+        ModuleConfig moduleSelection = config.getDefaultModSelection();
+        moduleSelection.clear();
+        dependencyNames.forEach(moduleSelection::addModule);
+
+        WorldGenerationConfig worldGenerationConfig = config.getWorldGeneration();
+        worldGenerationConfig.setDefaultGenerator(worldGeneratorUri);
+        worldGenerationConfig.setWorldTitle(WORLD_TITLE);
+        worldGenerationConfig.setDefaultSeed(DEFAULT_SEED);
     }
 
     @Override
     public GameManifest createGameManifest() {
-        GameManifest gameManifest = new GameManifest();
-
-        gameManifest.setTitle("testworld");
-        gameManifest.setSeed("seed");
-        DependencyResolver resolver = new DependencyResolver(CoreRegistry.get(ModuleManager.class).getRegistry());
-
-        Set<Name> dependencyNames = dependencies.stream().map(Name::new).collect(Collectors.toSet());
-        logger.info("Building manifest for module dependencies: {}", dependencyNames);
-
-        // Include the MTE module to provide world generators and suchlike.
-        dependencyNames.add(new Name("ModuleTestingEnvironment"));
-
-        ResolutionResult result = resolver.resolve(dependencyNames);
-        if (!result.isSuccess()) {
-            logger.error("Unable to resolve modules: {}", dependencyNames);
-        }
-
-        for (Module module : result.getModules()) {
-            logger.info("Loading module {} {}", module.getId(), module.getVersion());
-            gameManifest.addModule(module.getId(), module.getVersion());
-        }
+        GameManifest gameManifest = super.createGameManifest();
 
         float timeOffset = 0.25f + 0.025f;  // Time at dawn + little offset to spawn in a brighter env.
-        WorldInfo worldInfo = new WorldInfo(TerasologyConstants.MAIN_WORLD, gameManifest.getSeed(),
-                (long) (WorldTime.DAY_LENGTH * timeOffset), new SimpleUri(worldGeneratorUri));
-        gameManifest.addWorld(worldInfo);
+        gameManifest.getWorldInfo(TerasologyConstants.MAIN_WORLD).setTime((long) (WorldTime.DAY_LENGTH * timeOffset));
         return gameManifest;
+    }
+
+    @Override
+    public void init(GameEngine engine) {
+        // We want to modify Config before super.init calls createGameManifest, but the child context
+        // does not exist before we call super.init.
+        configForTest(((TerasologyEngine) engine).getFromEngineContext(Config.class));
+        super.init(engine);
     }
 }


### PR DESCRIPTION
Using config settings means we don't have to override and duplicate as much code in `createGameManifest`. In particular, this means we have one less place doing its own invocation of the module dependency resolver.