### PR TITLE
feat: async functions to make sure blocks/chunks are loaded

### DIFF
--- a/src/main/java/org/terasology/moduletestingenvironment/ChunkRegionFuture.java
+++ b/src/main/java/org/terasology/moduletestingenvironment/ChunkRegionFuture.java
@@ -1,0 +1,166 @@
+// Copyright 2021 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+package org.terasology.moduletestingenvironment;
+
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.SettableFuture;
+import org.joml.Vector3fc;
+import org.joml.Vector3i;
+import org.joml.Vector3ic;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.terasology.engine.entitySystem.entity.EntityManager;
+import org.terasology.engine.entitySystem.entity.EntityRef;
+import org.terasology.engine.entitySystem.entity.internal.EntityScope;
+import org.terasology.engine.logic.location.LocationComponent;
+import org.terasology.engine.world.block.BlockRegion;
+import org.terasology.engine.world.block.BlockRegionc;
+import org.terasology.engine.world.chunks.Chunk;
+import org.terasology.engine.world.chunks.ChunkRegionListener;
+import org.terasology.engine.world.chunks.localChunkProvider.RelevanceSystem;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+@SuppressWarnings("checkstyle:finalclass")
+public class ChunkRegionFuture {
+    public static final int REQUIRED_CHUNK_MARGIN = 1;
+
+    private static final Logger logger = LoggerFactory.getLogger(ChunkRegionFuture.class);
+
+    protected final SettableFuture<ChunkRegionFuture> future = SettableFuture.create();
+    protected final Set<Chunk> loadedChunks = new HashSet<>();
+    protected final BlockRegion chunks = new BlockRegion(BlockRegion.INVALID);
+
+    private final EntityRef entity;
+
+    private ChunkRegionFuture(EntityRef entity, Function<ChunkRegionListener, BlockRegionc> chunks) {
+        this.entity = entity;
+        this.chunks.set(chunks.apply(new Listener(this::onChunkRelevant)));
+    }
+
+    /**
+     *
+     * @param entityManager used to create the entity that depends on this region
+     * @param relevanceSystem the authority on what is relevant
+     * @param center a point to center the region around, in block coordinates
+     * @param sizeInChunks the size of the region, in chunks
+     */
+    static ChunkRegionFuture create(EntityManager entityManager, RelevanceSystem relevanceSystem, Vector3fc center,
+                                            Vector3ic sizeInChunks) {
+        EntityRef entity = entityManager.create(new LocationComponent(center));
+        entity.setScope(EntityScope.GLOBAL);
+
+        Vector3ic correctedSizeInChunks = addMargin(sizeInChunks);
+
+        Function<ChunkRegionListener, BlockRegionc> makeChunksRelevant = listener -> {
+            BlockRegionc paddedRegion =
+                    relevanceSystem.addRelevanceEntity(entity, correctedSizeInChunks, listener);
+            return removeMargin(paddedRegion);
+        };
+
+        return new ChunkRegionFuture(entity, makeChunksRelevant);
+    }
+
+    /**
+     * Removes the margin added by {@link #addMargin}.
+     *
+     * @return new instance of the contained region
+     */
+    private static BlockRegionc removeMargin(BlockRegionc relRegion) {
+        return relRegion.expand(-REQUIRED_CHUNK_MARGIN, -REQUIRED_CHUNK_MARGIN, -REQUIRED_CHUNK_MARGIN,
+                new BlockRegion(BlockRegion.INVALID));
+    }
+
+    private static Vector3ic addMargin(Vector3ic sizeInChunks) {
+        Vector3i desiredSize = new Vector3i(sizeInChunks);
+
+        // FIXME: add an interface to RelevanceSystem that takes radii as inputs,
+        //     so we don't have to reverse-engineer its rounding algorithms.
+        // Dimensions of relevance regions are odd-numbered so they can be symmetrical around
+        // their center.
+        desiredSize.x |= 1;
+        desiredSize.y |= 1;
+        desiredSize.z |= 1;
+
+        // FIXME: Is the complete relevance region not actually loaded‽
+        // Need a buffer on either side.
+        desiredSize.add(2 * REQUIRED_CHUNK_MARGIN, 2 * REQUIRED_CHUNK_MARGIN, 2 * REQUIRED_CHUNK_MARGIN);
+        return desiredSize;
+    }
+
+    /**
+     * Completes when all expected chunks have loaded.
+     * <p>
+     * <b>Experimental:</b> Unsure which objects are useful to return, I made a bunch of them available
+     * through this class and we return the whole thing. Though returning a future for an object
+     * the caller already has doesn't make a lot of sense.
+     *
+     * @return complete when all expected chunks have loaded
+     */
+    public ListenableFuture<ChunkRegionFuture> getFuture() {
+        return future;
+    }
+
+    @SuppressWarnings("unused")
+    public Set<Chunk> getLoadedChunks() {
+        return Collections.unmodifiableSet(loadedChunks);
+    }
+
+    /** The entity defining the relevance region. */
+    public EntityRef getEntity() {
+        return entity;
+    }
+
+    @SuppressWarnings("unused")
+    public BlockRegionc getChunkRegion() {
+        return chunks;
+    }
+
+    protected void onChunkRelevant(Chunk chunk) {
+        loadedChunks.add(chunk);
+        if (chunks.isValid()) {
+            logger.debug("Got chunk {} / {}", loadedChunks.size(), chunks.volume());
+            if (loadedChunks.size() >= chunks.volume() && !future.isDone()) {
+                future.set(this);
+            }
+        }
+    }
+
+    /** Adapts a {@code Consumer<Chunk>} to a {@code ChunkRegionListener}. */
+    private static class Listener implements ChunkRegionListener {
+        private final Consumer<Chunk> onChunk;
+
+        Listener(Consumer<Chunk> onChunk) {
+            this.onChunk = onChunk;
+        }
+
+        @Override
+        public void onChunkRelevant(Vector3ic pos, Chunk chunk) {
+            onChunk.accept(chunk);
+        }
+
+        @Override
+        public void onChunkIrrelevant(Vector3ic pos) {
+            // FIXME: Document why this IS, in fact, called regularly.
+            //     We thought this would be called when the location of the entity changes,
+            //     meaning previously-relevant chunks are no longer in range and become irrelevant.
+            //     But in practice, we see this being called even when we aren't doing anything to
+            //     change the location of the region's entity.
+//            UnsupportedOperationException error = new UnsupportedOperationException(String.format(
+//                    "No chunks in this region should be irrelevant! That was the whole point!" +
+//                            "Position: %s",
+//                    pos
+//            ));
+//            if (failOnIrrelevantEvent) {
+//                future.setException(error);
+//                throw error;
+//            }
+            // logger.warn("Irrelevant???", error);
+        }
+    }
+}

--- a/src/main/java/org/terasology/moduletestingenvironment/ModuleTestingEnvironment.java
+++ b/src/main/java/org/terasology/moduletestingenvironment/ModuleTestingEnvironment.java
@@ -80,8 +80,8 @@ import static org.mockito.Mockito.when;
 
 /**
  * Base class for tests involving full {@link TerasologyEngine} instances. View the tests included in this module for
- * simple usage examples
- * <p>
+ * simple usage examples.
+ *
  * <h2>Introduction</h2>
  * If test classes extend this class will create a new host engine for each {@code @Test} method. If the testing
  * environment is used by composition {@link #setup()} and {@link #tearDown()} need to be called explicitly. This can be
@@ -92,7 +92,7 @@ import static org.mockito.Mockito.when;
  * use CoreRegistry in your test code, as this is manipulated by the test environment to allow multiple instances of the
  * engine to peacefully coexist. You should always use the returned context reference to manipulate or inspect the
  * CoreRegistry of a given engine instance.
- * <p>
+ *
  * <h2>Client Engine Instances</h2>
  * Client instances can be easily created via {@link #createClient()} which returns the in-game context of the created
  * engine instance. When this method returns, the client will be in the {@link StateIngame} state and connected to the
@@ -101,7 +101,7 @@ import static org.mockito.Mockito.when;
  * Engines can be run while a condition is true via {@link #runWhile(Supplier)} <br>{@code runWhile(()-> true);}
  * <p>
  * or conversely run until a condition is true via {@link #runUntil(Supplier)} <br>{@code runUntil(()-> false);}
- * <p>
+ *
  * <h2>Specifying Dependencies</h2>
  * By default the environment will load only the engine itself. In order to load your own module code, you must override
  * {@link #getDependencies()} in your test subclass.
@@ -122,38 +122,37 @@ import static org.mockito.Mockito.when;
  * }
  * }
  * </pre>
- * <p>
+ *
  * <h2>Reuse the MTE for Multiple Tests</h2>
  * To use the same engine for multiple tests the testing environment can be set up explicitly and shared between tests.
  * To configure module dependencies or the world generator an anonymous class may be used.
  * <pre>
- * {@code
  * private static ModuleTestingEnvironment context;
  *
- * @BeforeAll
+ * &#64;BeforeAll
  * public static void setup() throws Exception {
  *     context = new ModuleTestingEnvironment() {
- *     @Override
- *     public Set<String> getDependencies() {
+ *     &#64;Override
+ *     public Set&lt;String&gt; getDependencies() {
  *         return Sets.newHashSet("ModuleTestingEnvironment");
  *     }
  *     };
  *     context.setup();
  * }
  *
- * @AfterAll
+ * &#64;AfterAll
  * public static void tearDown() throws Exception {
  *     context.tearDown();
  * }
  *
- * @Test
+ * &#64;Test
  * public void someTest() {
  *     Context hostContext = context.getHostContext();
  *     EntityManager entityManager = hostContext.get(EntityManager.class);
  *     // ...
  * }
- * }
  * </pre>
+ *
  * @deprecated Use the {@link MTEExtension} or {@link IsolatedMTEExtension} instead with JUnit5.
  */
 @Deprecated
@@ -450,16 +449,16 @@ public class ModuleTestingEnvironment {
     }
 
     /**
-     * Sets the safety timeout (default 30000ms). The safety timeout applies to `runWhile` and related helpers, and
-     * stops execution when the specified number of real time milliseconds has passsed. Note that this is different from
+     * Sets the safety timeout (default 30s).
+     *
+     * @param safetyTimeoutMs The safety timeout applies to {@link #runWhile runWhile} and related helpers, and
+     * stops execution when the specified number of real time milliseconds has passed. Note that this is different from
      * the timeout parameter of those methods, which is specified in game time.
-     *
-     * When a single run* helper invocation exceeds the safety timeout, MTE asserts false to explicitly fail the test.
-     *
+     * <p>
+     * When a single {@code run*} helper invocation exceeds the safety timeout, MTE asserts false to explicitly fail the test.
+     * <p>
      * The safety timeout exists to prevent indefinite execution in Jenkins or long IDE test runs, and should be
      * adjusted as needed so that tests pass reliably in all environments.
-     *
-     * @param safetyTimeoutMs
      */
     public void setSafetyTimeoutMs(long safetyTimeoutMs) {
         this.safetyTimeoutMs = safetyTimeoutMs;
@@ -515,10 +514,10 @@ public class ModuleTestingEnvironment {
      * In standalone module environments (i.e. Jenkins CI builds) the CWD is the module under test. When it uses MTE
      * it very likely needs to load itself as a module, but it won't be loadable from the typical path such as
      * ./modules. This means that modules using MTE would always fail CI tests due to failing to load themselves.
-     *
+     * <p>
      * For these cases we try to load the CWD (via the installPath) as a module and put it in the global module
      * registry.
-     *
+     * <p>
      * This process is based on how ModuleManagerImpl uses ModulePathScanner to scan for available modules.
      *
      * @param terasologyEngine

--- a/src/main/java/org/terasology/moduletestingenvironment/TestEventReceiver.java
+++ b/src/main/java/org/terasology/moduletestingenvironment/TestEventReceiver.java
@@ -1,18 +1,5 @@
-/*
- * Copyright 2017 MovingBlocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2021 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
 package org.terasology.moduletestingenvironment;
 
 import com.google.common.collect.Lists;
@@ -38,7 +25,7 @@ import java.util.function.BiConsumer;
  * The receiver automatically collects events of the given type sent to its {@link Context}.
  *
  * <pre>
- * {@literal
+ * {@code
  * TestEventReceiver<DropItemEvent> dropReceiver = new TestEventReceiver<>(getHostContext(), DropItemEvent.class)
  * // fire some events
  * for (DropItemEvent event : dropReceiver.getEvents()) {
@@ -48,16 +35,16 @@ import java.util.function.BiConsumer;
  * </pre>
  * Users can optionally supply a {@link BiConsumer} to handle the events with custom logic.
  * <pre>
- * {@literal
+ * {@code
  * TestEventReceiver receiver = new TestEventReceiver<>(context, DropItemEvent.class, (event, entity) -> {
  *   // do something with the event or entity
  * });
  * }
  * </pre>
- * Additionally, a list of required <emph>component types</emph> can be passed to the event receiver. This is equivalent
+ * Additionally, a list of required <em>component types</em> can be passed to the event receiver. This is equivalent
  * to listing the components in the {@code ReceiveEvent(components = {...}} block of a regular event handler.
  * <pre>
- * {code
+ * {@code
  * TestEventReceiver receiver = new TestEventReceiver<>(context, DropItemEvent.class, (event, entity) -> {
  *   // do something with the event or entity
  * }, MagicItemComponent.class);
@@ -68,7 +55,7 @@ import java.util.function.BiConsumer;
  * AutoCloseable}):
  *
  * <pre>
- * {@literal
+ * {@code
  * try (TestEventReceiver<DropItemEvent> spy = new TestEventReceiver<>(getHostContext(), DropItemEvent.class)) {
  *   drops = spy.getEntityRefs();
  * }
@@ -91,17 +78,15 @@ public class TestEventReceiver<T extends Event> implements AutoCloseable, EventR
      * <p>
      * The following signature of a {@code TestEventReceiver} is equivalent to the event handler below:
      * <pre>
-     * {@code
-     * TestEventReceiver receiver = new TestEventReceiver<>(context, MyEvent.class, (event, entity) -> {
+     * TestEventReceiver receiver = new TestEventReceiver&lt;&gt;(context, MyEvent.class, (event, entity) -&gt; {
      *   // do something with the event or entity
      * }, MyComponent.class);
      *
      * // ... corresponds to
      *
-     * @ReceiveEvent(components = {MyComponent.class})
+     * &#64;ReceiveEvent(components = {MyComponent.class})
      * public void handler(MyEvent event, EntityRef entity) {
      *     // do something with the event or entity
-     * }
      * }
      * </pre>
      *

--- a/src/main/java/org/terasology/moduletestingenvironment/fixtures/DummyWorldGenerator.java
+++ b/src/main/java/org/terasology/moduletestingenvironment/fixtures/DummyWorldGenerator.java
@@ -1,18 +1,5 @@
-/*
- * Copyright 2017 MovingBlocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2021 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
 package org.terasology.moduletestingenvironment.fixtures;
 
 import org.terasology.engine.core.SimpleUri;
@@ -24,6 +11,7 @@ import org.terasology.engine.world.generator.plugin.WorldGeneratorPluginLibrary;
 
 @RegisterWorldGenerator(id = "dummy", displayName = "dummy")
 public class DummyWorldGenerator extends BaseFacetedWorldGenerator {
+    public static final int SURFACE_HEIGHT = 40;
 
     @In
     private WorldGeneratorPluginLibrary worldGeneratorPluginLibrary;
@@ -35,7 +23,7 @@ public class DummyWorldGenerator extends BaseFacetedWorldGenerator {
     @Override
     protected WorldBuilder createWorld() {
         return new WorldBuilder(worldGeneratorPluginLibrary)
-                .addProvider(new FlatSurfaceHeightProvider(40))
+                .addProvider(new FlatSurfaceHeightProvider(SURFACE_HEIGHT))
                 .addPlugins();
     }
 }

--- a/src/test/java/org/terasology/moduletestingenvironment/ChunkRegionFutureTest.java
+++ b/src/test/java/org/terasology/moduletestingenvironment/ChunkRegionFutureTest.java
@@ -1,0 +1,60 @@
+// Copyright 2021 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+package org.terasology.moduletestingenvironment;
+
+import org.joml.Vector3f;
+import org.joml.Vector3fc;
+import org.joml.Vector3i;
+import org.joml.Vector3ic;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.terasology.engine.entitySystem.entity.EntityManager;
+import org.terasology.engine.registry.In;
+import org.terasology.engine.world.WorldProvider;
+import org.terasology.engine.world.block.Block;
+import org.terasology.engine.world.chunks.Chunks;
+import org.terasology.engine.world.chunks.localChunkProvider.RelevanceSystem;
+import org.terasology.moduletestingenvironment.fixtures.DummyWorldGenerator;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.terasology.engine.world.block.BlockManager.AIR_ID;
+import static org.terasology.engine.world.block.BlockManager.UNLOADED_ID;
+
+@Tag("MteTest")
+@ExtendWith(MTEExtension.class)
+class ChunkRegionFutureTest {
+
+    Vector3fc center = new Vector3f(2021, DummyWorldGenerator.SURFACE_HEIGHT, 1117);
+    Vector3ic sizeInChunks = new Vector3i(9, 3, 5);
+
+    @In
+    WorldProvider world;
+
+    @Test
+    void createChunkRegionFuture(EntityManager entityManager, RelevanceSystem relevanceSystem, ModuleTestingHelper mte) {
+        ChunkRegionFuture chunkRegionFuture = ChunkRegionFuture.create(entityManager, relevanceSystem, center, sizeInChunks);
+
+        mte.runUntil(chunkRegionFuture.getFuture());
+
+        Vector3fc someplaceInside = center.add(
+                 sizeInChunks.x() * Chunks.SIZE_X / 3f, 0, 0,
+                new Vector3f());
+        Vector3fc someplaceOutside = center.add(
+                0, 0, sizeInChunks.z() * Chunks.SIZE_Z * 3f,
+                new Vector3f());
+
+        Block blockAtCenter = world.getBlock(center);
+        Block blockInside = world.getBlock(someplaceInside);
+        Block blockOutside = world.getBlock(someplaceOutside);
+
+        assertThat(blockAtCenter).isNotNull();
+        assertThat(blockAtCenter.getURI()).isEqualTo(AIR_ID);
+
+        assertThat(blockInside).isNotNull();
+        assertThat(blockInside.getURI()).isEqualTo(AIR_ID);
+
+        assertThat(blockOutside.getURI()).isEqualTo(UNLOADED_ID);
+    }
+}

--- a/src/test/java/org/terasology/moduletestingenvironment/ModuleTestingEnvironmentTest.java
+++ b/src/test/java/org/terasology/moduletestingenvironment/ModuleTestingEnvironmentTest.java
@@ -1,0 +1,39 @@
+// Copyright 2021 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+package org.terasology.moduletestingenvironment;
+
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.SettableFuture;
+import com.google.common.util.concurrent.UncheckedTimeoutException;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@Tag("MteTest")
+@ExtendWith(MTEExtension.class)
+public class ModuleTestingEnvironmentTest {
+
+    public static final int THE_ANSWER = 42;
+
+    @Test
+    public void runUntilWithUnsatisfiedFutureExplainsTimeout(ModuleTestingHelper mte) {
+        SettableFuture<?> unsatisfiedFuture = SettableFuture.create();
+
+        UncheckedTimeoutException exception = assertThrows(UncheckedTimeoutException.class,
+                // TODO: change the timeout for this test so it doesn't always take
+                //     a minimum of 30 seconds.
+                () -> mte.runUntil(unsatisfiedFuture));
+        assertThat(exception).hasMessageThat().contains("default timeout");
+    }
+
+    @Test
+    public void runUntilWithImmediateFutureReturnsValue(ModuleTestingHelper mte) {
+        ListenableFuture<Integer> valueFuture = Futures.immediateFuture(THE_ANSWER);
+        assertThat(mte.runUntil(valueFuture)).isEqualTo(THE_ANSWER);
+    }
+}


### PR DESCRIPTION
This provides a more powerful version of the `forceAndWaitForGeneration` helper method. The new `makeBlocksRelevant` and `makeChunksRelevant` methods load all required chunks to cover the given region.

## Depends on:
- [x] https://github.com/MovingBlocks/Terasology/pull/4902

## Reviewers:
 - Which things do you think most need documentation?
 - `ChunkRegionFutureTest` contains one test.
   - Is it clear to you what it is testing and what information is relevant?
   - What additional tests would you need in order to feel comfortable working on this code and confident in its operation?

