### PR TITLE
chore: make runUntil/runWhile return values consistent

### DIFF
--- a/src/main/java/org/terasology/moduletestingenvironment/ModuleTestingEnvironment.java
+++ b/src/main/java/org/terasology/moduletestingenvironment/ModuleTestingEnvironment.java
@@ -152,6 +152,10 @@ public class ModuleTestingEnvironment {
     public static final long DEFAULT_SAFETY_TIMEOUT = 60000;
     public static final long DEFAULT_GAME_TIME_TIMEOUT = 30000;
     private static final Logger logger = LoggerFactory.getLogger(ModuleTestingEnvironment.class);
+
+    PathManager pathManager;
+    PathManagerProvider.Cleaner pathManagerCleaner;
+
     private final Set<String> dependencies = Sets.newHashSet("engine");
     private String worldGeneratorUri = "moduletestingenvironment:dummy";
     private boolean doneLoading;
@@ -159,9 +163,6 @@ public class ModuleTestingEnvironment {
     private Context hostContext;
     private final List<TerasologyEngine> engines = Lists.newArrayList();
     private long safetyTimeoutMs = DEFAULT_SAFETY_TIMEOUT;
-
-    PathManager pathManager;
-    PathManagerProvider.Cleaner pathManagerCleaner;
 
     /**
      * Set up and start the engine as configured via this environment.
@@ -434,9 +435,10 @@ public class ModuleTestingEnvironment {
         System.setProperty(ModuleManager.LOAD_CLASSPATH_MODULES_PROPERTY, "true");
 
         // create temporary home paths so the MTE engines don't overwrite config/save files in your real home path
+        // FIXME: Collisions when attempting to do multiple simultaneous createEngines.
+        //    (PathManager will need to be set in Context, not a process-wide global.)
         Path path = Files.createTempDirectory("terasology-mte-engine");
-        PathManager pathManager = PathManager.getInstance();
-        pathManager.useOverrideHomePath(path);
+        PathManager.getInstance().useOverrideHomePath(path);
         logger.info("Created temporary engine home path: {}", path);
 
         // JVM will delete these on normal termination but not exceptions.

--- a/src/main/java/org/terasology/moduletestingenvironment/ModuleTestingEnvironment.java
+++ b/src/main/java/org/terasology/moduletestingenvironment/ModuleTestingEnvironment.java
@@ -215,7 +215,7 @@ public class ModuleTestingEnvironment {
      * Setting dependencies for using by {@link ModuleTestingEnvironment}.
      *
      * @param dependencies the set of module names to load
-     * @throws IllegalStateException if you try'd setWorldGeneratorUrl after {@link
+     * @throws IllegalStateException if you tried setWorldGeneratorUrl after {@link
      *         ModuleTestingEnvironment#setup()}
      */
     void setDependencies(Set<String> dependencies) {
@@ -277,9 +277,10 @@ public class ModuleTestingEnvironment {
 
     /**
      * Runs tick() on the engine until f evaluates to true or DEFAULT_GAME_TIME_TIMEOUT milliseconds have passed in game time
+     * @return true if execution timed out
      */
-    public void runUntil(Supplier<Boolean> f) {
-        runWhile(() -> !f.get());
+    public boolean runUntil(Supplier<Boolean> f) {
+        return runWhile(() -> !f.get());
     }
 
     /**
@@ -293,9 +294,10 @@ public class ModuleTestingEnvironment {
 
     /**
      * Runs tick() on the engine while f evaluates to true or until DEFAULT_GAME_TIME_TIMEOUT milliseconds have passed
+     * @return true if execution timed out
      */
-    public void runWhile(Supplier<Boolean> f) {
-        runWhile(DEFAULT_GAME_TIME_TIMEOUT, f);
+    public boolean runWhile(Supplier<Boolean> f) {
+        return runWhile(DEFAULT_GAME_TIME_TIMEOUT, f);
     }
 
     /**


### PR DESCRIPTION
Extracted from #66, this is a few adjustments to methods that were returning `void`, plus some additional checks in `runWhile` against the loop not exiting when it should.

This PR shouldn't change anything in normal execution.  
(But erring tests might err differently.)